### PR TITLE
CRUD para la gestión del inventario de productos terminados

### DIFF
--- a/app/Filament/Resources/FinishedProductInventoryResource.php
+++ b/app/Filament/Resources/FinishedProductInventoryResource.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FinishedProductInventoryResource\Pages;
+use App\Models\FinishedProductInventory;
+use Filament\Forms;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class FinishedProductInventoryResource extends Resource
+{
+    protected static ?string $model = FinishedProductInventory::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-cube';
+
+    protected static ?string $navigationGroup = 'Inventarios';
+
+    protected static ?string $navigationLabel = 'Inventario de Productos';
+
+    protected static ?string $modelLabel = 'Inventario de Producto';
+
+    protected static ?string $pluralModelLabel = 'Inventario de Productos';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make("Información del inventario")
+                    ->description("Información del inventario de productos")
+                    ->columns(2)
+                    ->schema([
+                        Forms\Components\Select::make('branch_id')
+                            ->relationship('branch', 'name')
+                            ->required()
+                            ->searchable()
+                            ->preload()
+                            ->label('Sucursal'),
+
+                        Forms\Components\Select::make('product_id')
+                            ->relationship('product', 'name')
+                            ->required()
+                            ->unique(
+                                FinishedProductInventory::class,
+                                modifyRuleUsing: fn($rule, $get) => $rule->where('branch_id', $get('branch_id')),
+                                ignoreRecord: true,
+                            )
+                            ->validationMessages([
+                                'unique' => 'El producto ya existe en esta sucursal.',
+                            ])
+                            ->searchable()
+                            ->preload()
+                            ->label('Producto'),
+
+                        Forms\Components\TextInput::make('stock')
+                            ->required()
+                            ->numeric()
+                            ->minValue(0)
+                            ->disabled(fn($livewire) => $livewire instanceof Pages\EditFinishedProductInventory)
+                            ->dehydrated(fn($livewire) => !($livewire instanceof Pages\EditFinishedProductInventory))
+                            ->helperText(fn($livewire) => $livewire instanceof Pages\EditFinishedProductInventory ?
+                                'El stock se gestiona mediante el kardex y no puede ser modificado directamente.' : null)
+                            ->label('Existencia'),
+
+                        Forms\Components\TextInput::make('min_stock')
+                            ->required()
+                            ->numeric()
+                            ->minValue(0)
+                            ->label('Existencia mínima'),
+                    ])
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('branch.name')
+                    ->searchable()
+                    ->sortable()
+                    ->label('Sucursal'),
+                Tables\Columns\TextColumn::make('product.name')
+                    ->searchable()
+                    ->sortable()
+                    ->label('Producto'),
+                Tables\Columns\TextColumn::make('stock')
+                    ->numeric()
+                    ->sortable()
+                    ->label('Existencia'),
+                Tables\Columns\TextColumn::make('min_stock')
+                    ->numeric()
+                    ->sortable()
+                    ->label('Existencia mínima'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true)
+                    ->label('Creado'),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true)
+                    ->label('Actualizado'),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('branch_id')
+                    ->relationship('branch', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->label('Sucursal'),
+                Tables\Filters\SelectFilter::make('product_id')
+                    ->relationship('product', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->label('Producto'),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListFinishedProductInventories::route('/'),
+            'create' => Pages\CreateFinishedProductInventory::route('/create'),
+            'view' => Pages\ViewFinishedProductInventory::route('/{record}'),
+            'edit' => Pages\EditFinishedProductInventory::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/FinishedProductInventoryResource/Pages/CreateFinishedProductInventory.php
+++ b/app/Filament/Resources/FinishedProductInventoryResource/Pages/CreateFinishedProductInventory.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\FinishedProductInventoryResource\Pages;
+
+use App\Filament\Resources\FinishedProductInventoryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateFinishedProductInventory extends CreateRecord
+{
+    protected static string $resource = FinishedProductInventoryResource::class;
+}

--- a/app/Filament/Resources/FinishedProductInventoryResource/Pages/EditFinishedProductInventory.php
+++ b/app/Filament/Resources/FinishedProductInventoryResource/Pages/EditFinishedProductInventory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Filament\Resources\FinishedProductInventoryResource\Pages;
+
+use App\Filament\Resources\FinishedProductInventoryResource;
+use App\Models\FinishedProductInventory;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+use Filament\Forms;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+
+class EditFinishedProductInventory extends EditRecord
+{
+    protected static string $resource = FinishedProductInventoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+        ];
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('view', ['record' => $this->record]);
+    }
+}

--- a/app/Filament/Resources/FinishedProductInventoryResource/Pages/ListFinishedProductInventories.php
+++ b/app/Filament/Resources/FinishedProductInventoryResource/Pages/ListFinishedProductInventories.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FinishedProductInventoryResource\Pages;
+
+use App\Filament\Resources\FinishedProductInventoryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListFinishedProductInventories extends ListRecords
+{
+    protected static string $resource = FinishedProductInventoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FinishedProductInventoryResource/Pages/ViewFinishedProductInventory.php
+++ b/app/Filament/Resources/FinishedProductInventoryResource/Pages/ViewFinishedProductInventory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FinishedProductInventoryResource\Pages;
+
+use App\Filament\Resources\FinishedProductInventoryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewFinishedProductInventory extends ViewRecord
+{
+    protected static string $resource = FinishedProductInventoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Models/FinishedProductInventory.php
+++ b/app/Models/FinishedProductInventory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FinishedProductInventory extends Model
+{
+    use HasFactory;
+
+    protected $table = 'finished_product_inventories';
+
+    protected $fillable = [
+        'product_id',
+        'stock',
+        'min_stock',
+        'branch_id',
+    ];
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
+    }
+}

--- a/database/migrations/2025_04_14_064248_create_finished_product_inventories_table.php
+++ b/database/migrations/2025_04_14_064248_create_finished_product_inventories_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('finished_product_inventories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained('products')->restrictOnDelete();
+            $table->integer('stock')->default(0);
+            $table->integer('min_stock')->default(0);
+            $table->foreignId('branch_id')->constrained('branches')->restrictOnDelete();
+            $table->timestamps();
+
+            $table->unique(['branch_id', 'product_id'], 'UK_branch_product');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('finished_product_inventories');
+    }
+};


### PR DESCRIPTION
### Descripción
* Bloquear el campo de existencia cuando se esta editando el inventario, esto para proteger la información y que esta solo sea actualizada mediante el movimiento de inventario (Kardex)