### PR TITLE
fix(sales): reforzar prevención de ventas duplicadas por reconexión

### DIFF
--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -60,8 +60,9 @@ class SaleController extends Controller
         try {
             $employeeId = Auth::user()->employee_id;
 
-            $this->validateExistingReconciliation($employeeId);
-
+            // La verificación de idempotencia va antes que cualquier otra validación:
+            // un reintento de una venta ya registrada debe responder éxito aunque
+            // luego se haya creado el cuadre del día
             if ($uuid = $request->input('client_request_uuid')) {
                 $existingSale = Sale::where('client_request_uuid', $uuid)->first();
                 if ($existingSale) {
@@ -71,6 +72,8 @@ class SaleController extends Controller
                     );
                 }
             }
+
+            $this->validateExistingReconciliation($employeeId);
 
             $saleData = $this->prepareSaleData(collect($request->validated())->except('products')->toArray());
             $productsSaleData = $this->prepareSaleDetailsData($request['products']);


### PR DESCRIPTION
## Resumen
- Se reordena la verificación de idempotencia (`client_request_uuid`) en `SaleController::createSale` para que se ejecute **antes** del guard de cuadre diario (`validateExistingReconciliation`).
- Con el orden anterior, un reintento (por mala conexión) de una venta ya creada podía fallar con "ya existe un cuadre para hoy" en lugar de devolver la venta existente, dejando la puerta abierta a que el usuario reintentara de formas que derivaran en duplicados.

## Contexto
Se reportó que una venta creada con mala conexión terminó cuadruplicada. La causa principal está en la app Android (reintentos automáticos de Volley sin `client_request_uuid`, corregido en un commit aparte en `jugos_jaco_app`). Este cambio cierra el hueco correspondiente del lado de la API para que la protección de idempotencia ya existente (columna única `client_request_uuid`) cubra también este caso límite.

## Test plan
- [x] `php artisan test tests/Feature/SaleDuplicationPreventionTest.php` — 6 tests, 15 aserciones, todo en verde.
- [x] `php -l app/Http/Controllers/SaleController.php` — sin errores de sintaxis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)