### PR TITLE
fix(assigned-products): corregir sobrante por debajo del físico y duplicados en regalías/cambios

### DIFF
--- a/app/Exceptions/InsufficientAssignedStockException.php
+++ b/app/Exceptions/InsufficientAssignedStockException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+/**
+ * Error de negocio (no transitorio): la cantidad solicitada supera el sobrante
+ * del producto asignado. Se traduce a 422 para que la app móvil no reintente.
+ */
+class InsufficientAssignedStockException extends Exception
+{
+}

--- a/app/Http/Controllers/Api/AssignedProductMovementController.php
+++ b/app/Http/Controllers/Api/AssignedProductMovementController.php
@@ -3,13 +3,14 @@
 namespace App\Http\Controllers\Api;
 
 use App\Enums\AssignedProductMovementTypeEnum;
+use App\Exceptions\InsufficientAssignedStockException;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\AssignedProductMovementResource;
 use App\Models\AssignedProduct;
 use App\Models\AssignedProductMovement;
+use App\Models\DetailAssignedProduct;
 use App\Services\AssignedProductMovementService;
 use App\Traits\ApiResponse;
-use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -60,25 +61,55 @@ class AssignedProductMovementController extends Controller
      */
     public function createMovement(Request $request)
     {
+        // Fuera del try: una ValidationException no debe degradarse a 500,
+        // el móvil necesita el 422 con los campos inválidos.
+        $request->validate([
+            'detail_assigned_product_id' => 'required|exists:detail_assigned_products,id',
+            'type' => ['required', Rule::in(array_column(AssignedProductMovementTypeEnum::cases(), 'value'))],
+            'quantity' => 'required|numeric|min:0.01',
+            'note' => 'nullable|string|max:255',
+            'client_request_uuid' => 'nullable|uuid',
+        ]);
+
         try {
-            $request->validate([
-                'detail_assigned_product_id' => 'required|exists:detail_assigned_products,id',
-                'type' => ['required', Rule::in(array_column(AssignedProductMovementTypeEnum::cases(), 'value'))],
-                'quantity' => 'required|numeric|min:0.01',
-                'note' => 'nullable|string|max:255',
-            ]);
+            // Idempotencia: un reintento del móvil por respuesta perdida no debe
+            // volver a descontar el sobrante. Se resuelve antes de cualquier otra
+            // validación, igual que en SaleController::createSale.
+            if ($uuid = $request->input('client_request_uuid')) {
+                $existing = AssignedProductMovement::where('client_request_uuid', $uuid)->first();
+
+                if ($existing) {
+                    return $this->successResponse($existing, 'Movimiento ya registrado.');
+                }
+            }
+
+            $detail = $this->resolveOwnedDetail((int) $request->detail_assigned_product_id);
+
+            if (!$detail) {
+                return $this->errorResponse(
+                    new \Exception('El producto no pertenece a la asignación del empleado para hoy.'),
+                    403,
+                    'No autorizado para registrar movimientos sobre este producto.'
+                );
+            }
 
             $movement = $this->movementService->createMovement(
-                $request->detail_assigned_product_id,
-                $request->type,
-                $request->quantity,
-                $request->note
+                detailId: $detail->id,
+                type: $request->type,
+                quantity: (float) $request->quantity,
+                note: $request->note,
+                saleId: null,
+                clientRequestUuid: $uuid ?: null,
             );
 
             return $this->successResponse($movement, 'Movimiento registrado correctamente.', 201);
 
+        } catch (InsufficientAssignedStockException $e) {
+            // 422: error de negocio, reintentar no lo resuelve.
+            return $this->errorResponse($e, 422, $e->getMessage());
+
         } catch (\Exception $e) {
-            return $this->errorResponse($e, 500, $e->getMessage());
+            return $this->errorResponse($e, 500, 'Error al registrar el movimiento.');
         }
     }
 
@@ -88,10 +119,49 @@ class AssignedProductMovementController extends Controller
     public function deleteMovement($id)
     {
         try {
-            $this->movementService->deleteMovement($id);
+            $movement = AssignedProductMovement::find($id);
+
+            if (!$movement) {
+                return $this->errorResponse(
+                    new \Exception('Movimiento no encontrado.'),
+                    404,
+                    'Movimiento no encontrado.'
+                );
+            }
+
+            if (!$this->resolveOwnedDetail($movement->detail_assigned_product_id)) {
+                return $this->errorResponse(
+                    new \Exception('El movimiento no pertenece a la asignación del empleado para hoy.'),
+                    403,
+                    'No autorizado para eliminar este movimiento.'
+                );
+            }
+
+            $this->movementService->deleteMovement($movement->id);
+
             return $this->successResponse(null, 'Movimiento eliminado correctamente.');
         } catch (\Exception $e) {
             return $this->errorResponse($e, 500, 'Error al eliminar el movimiento.');
         }
+    }
+
+    /**
+     * Devuelve el detalle sólo si pertenece a la asignación de hoy del empleado
+     * autenticado. Sin esto cualquier usuario podía alterar el sobrante de otro
+     * vendedor enviando un id ajeno.
+     */
+    private function resolveOwnedDetail(int $detailId): ?DetailAssignedProduct
+    {
+        $employeeId = Auth::user()->employee_id;
+
+        if (!$employeeId) {
+            return null;
+        }
+
+        return DetailAssignedProduct::whereKey($detailId)
+            ->whereHas('assignedProduct', function ($query) use ($employeeId) {
+                $query->where('employee_id', $employeeId)->todayAssignments();
+            })
+            ->first();
     }
 }

--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\InsufficientAssignedStockException;
 use App\Http\Requests\SaleRequest;
 use App\Http\Resources\SaleDetailResource;
 use App\Http\Resources\SaleResource;
@@ -97,6 +98,9 @@ class SaleController extends Controller
                 );
             }
             return $this->errorResponse($qe, 500, "Error al crear la venta");
+
+        } catch (InsufficientAssignedStockException $e) {
+            return $this->errorResponse($e, 422, $e->getMessage());
 
         } catch (Exception $e) {
             return $this->errorResponse(

--- a/app/Models/AssignedProductMovement.php
+++ b/app/Models/AssignedProductMovement.php
@@ -14,6 +14,7 @@ class AssignedProductMovement extends Model
         'quantity',
         'note',
         'sale_id',
+        'client_request_uuid',
         'created_by',
     ];
 

--- a/app/Models/DetailAssignedProduct.php
+++ b/app/Models/DetailAssignedProduct.php
@@ -21,7 +21,7 @@ class DetailAssignedProduct extends Model
         'assigned_products_id',
     ];
 
-    protected $cast = [
+    protected $casts = [
         'quantity' => 'decimal:2',
         'sale_quantity' => 'decimal:2',
         'returned_quantity' => 'decimal:2',

--- a/app/Services/AssignedProductMovementService.php
+++ b/app/Services/AssignedProductMovementService.php
@@ -6,6 +6,8 @@ use App\Models\AssignedProduct;
 use App\Models\AssignedProductMovement;
 use App\Models\DetailAssignedProduct;
 use App\Enums\AssignedProductMovementTypeEnum;
+use App\Exceptions\InsufficientAssignedStockException;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Exception;
 
@@ -13,12 +15,56 @@ class AssignedProductMovementService
 {
     /**
      * Create a new movement (Change or Royalty) and update the assigned product detail accumulator.
+     *
+     * @param string|null $clientRequestUuid Clave de idempotencia: si ya existe un
+     *        movimiento con este uuid se devuelve el existente sin volver a acumular.
      */
-    public function createMovement(int $detailId, string $type, float $quantity, ?string $note = null, ?int $saleId = null): AssignedProductMovement
-    {
-        return DB::transaction(function () use ($detailId, $type, $quantity, $note, $saleId) {
+    public function createMovement(
+        int $detailId,
+        string $type,
+        float $quantity,
+        ?string $note = null,
+        ?int $saleId = null,
+        ?string $clientRequestUuid = null
+    ): AssignedProductMovement {
+        if ($clientRequestUuid) {
+            $existing = AssignedProductMovement::where('client_request_uuid', $clientRequestUuid)->first();
+
+            if ($existing) {
+                return $existing;
+            }
+        }
+
+        try {
+            return $this->persistMovement($detailId, $type, $quantity, $note, $saleId, $clientRequestUuid);
+        } catch (QueryException $qe) {
+            // Reintento concurrente con el mismo uuid: el índice único ya bloqueó
+            // la segunda inserción, devolvemos el movimiento que sí quedó registrado.
+            if ($clientRequestUuid) {
+                $existing = AssignedProductMovement::where('client_request_uuid', $clientRequestUuid)->first();
+
+                if ($existing) {
+                    return $existing;
+                }
+            }
+
+            throw $qe;
+        }
+    }
+
+    private function persistMovement(
+        int $detailId,
+        string $type,
+        float $quantity,
+        ?string $note,
+        ?int $saleId,
+        ?string $clientRequestUuid
+    ): AssignedProductMovement {
+        return DB::transaction(function () use ($detailId, $type, $quantity, $note, $saleId, $clientRequestUuid) {
             // 1. Find DetailAssignedProduct
-            $detail = DetailAssignedProduct::find($detailId);
+            // lockForUpdate: el acumulador se lee y se reescribe, sin bloqueo dos
+            // movimientos concurrentes se pisan y sólo uno queda contabilizado.
+            $detail = DetailAssignedProduct::lockForUpdate()->find($detailId);
 
             if (!$detail) {
                 throw new Exception("El detalle del producto asignado no existe.");
@@ -26,7 +72,7 @@ class AssignedProductMovementService
 
             // Check stock availability
             if ($detail->stock < $quantity) {
-                 throw new Exception("Stock insuficiente para realizar el movimiento. Stock actual: {$detail->stock}");
+                 throw new InsufficientAssignedStockException("Stock insuficiente para realizar el movimiento. Stock actual: {$detail->stock}");
             }
 
             // 2. Create Movement
@@ -36,6 +82,7 @@ class AssignedProductMovementService
                 'quantity' => $quantity,
                 'note' => $note,
                 'sale_id' => $saleId,
+                'client_request_uuid' => $clientRequestUuid,
                 'created_by' => auth()->id(),
             ]);
 
@@ -58,13 +105,14 @@ class AssignedProductMovementService
     {
         DB::transaction(function () use ($movementId) {
             $movement = AssignedProductMovement::findOrFail($movementId);
-            $detail = $movement->detailAssignedProduct;
-            
-            // Revert accumulator
+            $detail = DetailAssignedProduct::lockForUpdate()
+                ->findOrFail($movement->detail_assigned_product_id);
+
+            // Revert accumulator (nunca por debajo de 0)
             if ($movement->type === AssignedProductMovementTypeEnum::CHANGE) {
-                $detail->changes_quantity -= $movement->quantity;
+                $detail->changes_quantity = max(0, $detail->changes_quantity - $movement->quantity);
             } else {
-                $detail->royalties_quantity -= $movement->quantity;
+                $detail->royalties_quantity = max(0, $detail->royalties_quantity - $movement->quantity);
             }
             $detail->save();
             

--- a/app/Services/SaleService.php
+++ b/app/Services/SaleService.php
@@ -6,6 +6,7 @@ use App\Enums\SaleStatusEnum;
 use App\Enums\TypeInventoryManagementEnum;
 use App\Enums\PaymentTypeEnum;
 use App\Enums\PaymentTermEnum;
+use App\Exceptions\InsufficientAssignedStockException;
 use App\Models\AssignedProduct;
 use App\Models\DetailAssignedProduct;
 use App\Models\FinishedProductInventory;
@@ -132,6 +133,13 @@ class SaleService
             Log::error('Error DB en SaleService::createSale: ' . $qe->getMessage());
             throw $qe;
 
+        } catch (InsufficientAssignedStockException $e) {
+            // Se propaga sin envolver para que el controlador la traduzca a 422:
+            // reintentar no la resuelve.
+            DB::rollBack();
+            Log::warning('Stock insuficiente en SaleService::createSale: ' . $e->getMessage());
+            throw $e;
+
         } catch (Exception $e) {
             DB::rollBack();
             Log::error('Error en SaleService::createSale: ' . $e->getMessage());
@@ -148,13 +156,22 @@ class SaleService
      */
     protected function createSaleDetails(Sale $sale, array $productsData): void
     {
-        foreach ($productsData as $productData) {
-            // --- CASE: Royalty or Change → AssignedProductMovement ---
-            if (!empty($productData['movement_type'])) {
-                $this->createMovementFromSaleProduct($sale, $productData);
-                continue;
-            }
+        // El resultado no debe depender del orden en que el cliente arme el payload:
+        // las líneas de venta se procesan siempre primero y los movimientos
+        // (regalías/cambios) después, de modo que el control de stock de cada
+        // movimiento ya vea descontado lo vendido en este mismo ticket.
+        $saleLines = [];
+        $movementLines = [];
 
+        foreach ($productsData as $productData) {
+            if (!empty($productData['movement_type'])) {
+                $movementLines[] = $productData;
+            } else {
+                $saleLines[] = $productData;
+            }
+        }
+
+        foreach ($saleLines as $productData) {
             if (isset($productData['origin']) && $productData['origin'] === 'api') {
                 $productosAsignados = AssignedProduct::where('employee_id', Auth::user()->employee->id)
                     ->todayAssignments()
@@ -167,16 +184,19 @@ class SaleService
                         ->first();
 
                     if ($detail) {
-                        $nSaleQuantity = ($detail->sale_quantity ?? 0) + $productData['quantity'];
+                        // El sobrante disponible descuenta también regalías, cambios y
+                        // devoluciones: vender contra `quantity` permitía vender unidades
+                        // que ya habían salido como movimiento y dejaba el stock negativo.
+                        $available = (float) $detail->stock;
 
-                        if ($detail->quantity < $nSaleQuantity) {
-                            throw new Exception(
-                                "La cantidad a vender del producto {$productData['name']} excede la cantidad asignada"
+                        if ($available < $productData['quantity']) {
+                            throw new InsufficientAssignedStockException(
+                                "La cantidad a vender del producto {$productData['name']} excede el sobrante disponible ({$available})"
                             );
                         }
 
                         $detail->update([
-                            'sale_quantity' => $nSaleQuantity,
+                            'sale_quantity' => ($detail->sale_quantity ?? 0) + $productData['quantity'],
                         ]);
                     }
                 }
@@ -225,6 +245,11 @@ class SaleService
                     );
                 }
             }
+        }
+
+        // --- CASE: Royalty or Change → AssignedProductMovement ---
+        foreach ($movementLines as $productData) {
+            $this->createMovementFromSaleProduct($sale, $productData);
         }
     }
 

--- a/database/migrations/2026_08_10_000001_add_client_request_uuid_to_assigned_product_movements_table.php
+++ b/database/migrations/2026_08_10_000001_add_client_request_uuid_to_assigned_product_movements_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Clave de idempotencia para los movimientos creados desde la app móvil:
+     * un reintento por pérdida de respuesta no debe registrar la regalía/cambio
+     * dos veces y bajar el sobrante del vendedor.
+     *
+     * Mismo patrón que sales.client_request_uuid.
+     */
+    public function up(): void
+    {
+        Schema::table('assigned_product_movements', function (Blueprint $table) {
+            $table->char('client_request_uuid', 36)
+                ->nullable()
+                ->unique()
+                ->after('sale_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('assigned_product_movements', function (Blueprint $table) {
+            $table->dropUnique(['client_request_uuid']);
+            $table->dropColumn('client_request_uuid');
+        });
+    }
+};

--- a/docs/devflow/bug-fixes/2026-08-10-assigned-product-movements-known-issues.md
+++ b/docs/devflow/bug-fixes/2026-08-10-assigned-product-movements-known-issues.md
@@ -1,0 +1,101 @@
+# Productos asignados y movimientos — hallazgos pendientes
+
+**Fecha:** 2026-08-10
+**Origen:** revisión de `AssignedProductMovementService` y `SaleService::createSaleDetails`
+tras el reporte de "el sistema muestra que sobran menos productos de los que el
+vendedor lleva en físico".
+
+Los hallazgos 1, 2, 3, 4, 5 y 7 de esa revisión ya están corregidos
+(ver `AssignedProductStockGuardTest` y `AssignedProductMovementApiGuardTest`).
+Este documento registra los dos que quedaron **abiertos a propósito**.
+
+---
+
+## Pendiente A — `ClientVisitService::registerVisit` puede tumbar la venta completa
+
+**Estado:** documentado, sin corregir. Hoy no se manifiesta porque un cliente no
+puede estar asignado a dos empleados.
+
+**Dónde:** `app/Services/ClientVisitService.php:23-42`, invocado desde
+`app/Services/SaleService.php` (paso 7 de `createSale`).
+
+**Qué pasa:** el `updateOrCreate` busca la visita por la tripleta
+`(client_id, user_id, visited_date)`:
+
+```php
+ClientVisit::updateOrCreate(
+    ['client_id' => $clientId, 'user_id' => $userId, 'visited_date' => $date->toDateString()],
+    ['visited' => $visited]
+);
+```
+
+…pero el índice único de la tabla es sólo `(client_id, visited_date)`. La clave de
+búsqueda es más estricta que la restricción de la base: si dos usuarios distintos
+registran una venta al mismo cliente el mismo día, el segundo no encuentra la fila
+existente, intenta insertar y choca contra el índice único. La excepción se propaga
+hasta `SaleService::createSale`, que hace rollback: **la venta completa se pierde
+con un 500**, no sólo la visita.
+
+**Por qué no se manifiesta hoy:** la operación asigna cada cliente a un único
+empleado, así que en la práctica siempre es el mismo `user_id`.
+
+**Cuándo se va a manifestar:**
+- si un cliente pasa a ser atendido por dos vendedores (ruta compartida, cubrir
+  vacaciones, un supervisor que factura por el titular);
+- si un mismo vendedor cambia de usuario;
+- ya se reproduce hoy en SQLite dentro de los tests, porque el `visited_date`
+  guardado como datetime (`2026-08-10 00:00:00`) no empata con la búsqueda por
+  `toDateString()` (`2026-08-10`). Por eso `AssignedProductStockGuardTest` usa un
+  cliente distinto por venta en el caso de ventas consecutivas.
+
+**Cómo se arreglaría:**
+1. Alinear la clave del `updateOrCreate` con el índice único: buscar por
+   `(client_id, visited_date)` y mover `user_id` al array de valores; o bien
+2. ampliar el índice único a `(client_id, user_id, visited_date)` si el negocio sí
+   quiere una visita por vendedor; y
+3. en cualquier caso, **no dejar que un fallo al registrar la visita anule la venta**:
+   el registro de visita es un efecto secundario, no parte de la transacción de venta.
+
+---
+
+## Pendiente B — Movimientos huérfanos al borrar una venta
+
+**Estado:** documentado, sin corregir. Se aborda junto con el trabajo de borrado /
+anulación de ventas.
+
+**Dónde:** `database/migrations/..._add_sale_id_to_assigned_product_movements_table.php`
+
+```php
+$table->foreignId('sale_id')->nullable()->constrained('sales')->nullOnDelete();
+```
+
+**Qué pasa:** si se elimina una venta, sus regalías y cambios asociados **no se
+borran**: quedan con `sale_id = NULL` y los acumuladores `royalties_quantity` /
+`changes_quantity` del `DetailAssignedProduct` nunca se revierten. El sobrante del
+vendedor queda permanentemente por debajo del físico — exactamente el síntoma que
+originó esta revisión, pero por otra vía.
+
+Lo mismo aplica a `sale_quantity`: `SaleService` la incrementa al vender y no existe
+hoy ningún camino que la devuelva.
+
+**Qué falta cuando se implemente borrado/anulación de ventas:**
+
+1. **Revertir los movimientos**, no sólo desligarlos. `AssignedProductMovementService::deleteMovement`
+   ya revierte el acumulador correctamente (con `lockForUpdate` y piso en 0): hay que
+   invocarlo para cada movimiento con ese `sale_id` antes de borrar la venta, en la
+   misma transacción.
+2. **Revertir `sale_quantity`** de cada `DetailAssignedProduct` afectado por los
+   `SaleDetail` de la venta, también con `lockForUpdate`.
+3. **Decidir entre borrado y anulación.** El enum `SaleStatusEnum` ya tiene el caso
+   `CANCELLED` pero no hay flujo que lo use. Anular preservando el histórico es
+   preferible a borrar; en ese caso la reversión debe dispararse al pasar a
+   `CANCELLED`, no en el `delete`.
+4. **Bloquear la reversión si el día ya tiene cuadre** (`DailySalesReconciliation`):
+   revertir acumuladores de un día cerrado descuadra el cierre. Ver la validación
+   equivalente en `SaleController::validateExistingReconciliation`.
+5. **Cambiar `nullOnDelete()`**. Una vez que exista reversión explícita, el
+   `nullOnDelete` es una trampa: deja el dato inconsistente en silencio. O se pasa a
+   `restrictOnDelete` (forzando a anular antes de borrar) o a `cascadeOnDelete`
+   acompañado de la reversión del acumulador.
+6. **Tests de regresión**: venta con regalía → anular → `royalties_quantity` y
+   `sale_quantity` vuelven a su valor previo y `stock` vuelve al original.

--- a/tests/Feature/AssignedProductMovementApiGuardTest.php
+++ b/tests/Feature/AssignedProductMovementApiGuardTest.php
@@ -1,0 +1,221 @@
+<?php
+
+use App\Models\AssignedProduct;
+use App\Models\AssignedProductMovement;
+use App\Models\DetailAssignedProduct;
+use App\Models\Employee;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el endpoint de movimientos no tenía idempotencia (un reintento del
+ * móvil registraba la regalía dos veces y bajaba el sobrante) ni verificación de
+ * pertenencia (cualquier usuario podía alterar el sobrante de otro vendedor).
+ */
+
+function assignedDetailFor(User $user, array $overrides = []): DetailAssignedProduct
+{
+    $product = Product::factory()->create(['name' => 'Jugo Naranja', 'is_active' => true]);
+
+    $assignedProduct = AssignedProduct::factory()->create([
+        'employee_id' => $user->employee_id,
+        'date' => $overrides['date'] ?? now(),
+    ]);
+
+    return DetailAssignedProduct::factory()->create([
+        'assigned_products_id' => $assignedProduct->id,
+        'product_id' => $product->id,
+        'quantity' => $overrides['quantity'] ?? 50,
+        'sale_quantity' => 0,
+        'returned_quantity' => 0,
+        'changes_quantity' => 0,
+        'royalties_quantity' => 0,
+    ]);
+}
+
+// --- Fix 4: idempotencia ---
+
+it('registers the movement only once when the same client_request_uuid is retried', function () {
+    $user = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $this->actingAs($user, 'sanctum');
+
+    $detail = assignedDetailFor($user);
+    $uuid = (string) Str::uuid();
+
+    $payload = [
+        'detail_assigned_product_id' => $detail->id,
+        'type' => 'royalty',
+        'quantity' => 6,
+        'client_request_uuid' => $uuid,
+    ];
+
+    $this->postJson('/api/product-movements', $payload)->assertStatus(201);
+    $this->postJson('/api/product-movements', $payload)->assertStatus(200);
+
+    expect(AssignedProductMovement::count())->toBe(1);
+    expect((float) $detail->fresh()->royalties_quantity)->toBe(6.0);
+    expect((float) $detail->fresh()->stock)->toBe(44.0);
+});
+
+it('persists the client_request_uuid and returns the same movement on retry', function () {
+    $user = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $this->actingAs($user, 'sanctum');
+
+    $detail = assignedDetailFor($user);
+    $uuid = (string) Str::uuid();
+
+    $first = $this->postJson('/api/product-movements', [
+        'detail_assigned_product_id' => $detail->id,
+        'type' => 'change',
+        'quantity' => 2,
+        'client_request_uuid' => $uuid,
+    ]);
+
+    $second = $this->postJson('/api/product-movements', [
+        'detail_assigned_product_id' => $detail->id,
+        'type' => 'change',
+        'quantity' => 2,
+        'client_request_uuid' => $uuid,
+    ]);
+
+    expect($second->json('data.id'))->toBe($first->json('data.id'));
+    expect(AssignedProductMovement::where('client_request_uuid', $uuid)->count())->toBe(1);
+});
+
+it('still registers separate movements when no uuid is sent', function () {
+    $user = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $this->actingAs($user, 'sanctum');
+
+    $detail = assignedDetailFor($user);
+
+    $payload = [
+        'detail_assigned_product_id' => $detail->id,
+        'type' => 'royalty',
+        'quantity' => 3,
+    ];
+
+    $this->postJson('/api/product-movements', $payload)->assertStatus(201);
+    $this->postJson('/api/product-movements', $payload)->assertStatus(201);
+
+    expect(AssignedProductMovement::count())->toBe(2);
+    expect((float) $detail->fresh()->royalties_quantity)->toBe(6.0);
+});
+
+it('rejects a malformed client_request_uuid', function () {
+    $user = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $this->actingAs($user, 'sanctum');
+
+    $detail = assignedDetailFor($user);
+
+    $this->postJson('/api/product-movements', [
+        'detail_assigned_product_id' => $detail->id,
+        'type' => 'royalty',
+        'quantity' => 1,
+        'client_request_uuid' => 'no-es-un-uuid',
+    ])->assertJsonValidationErrors(['client_request_uuid']);
+});
+
+// --- Fix 4: errores de negocio no son 500 ---
+
+it('returns 422 instead of 500 when there is not enough stock', function () {
+    $user = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $this->actingAs($user, 'sanctum');
+
+    $detail = assignedDetailFor($user, ['quantity' => 5]);
+
+    $this->postJson('/api/product-movements', [
+        'detail_assigned_product_id' => $detail->id,
+        'type' => 'royalty',
+        'quantity' => 10,
+    ])->assertStatus(422);
+
+    expect(AssignedProductMovement::count())->toBe(0);
+    expect((float) $detail->fresh()->royalties_quantity)->toBe(0.0);
+});
+
+// --- Fix 5: pertenencia ---
+
+it('forbids creating a movement on another employee assignment', function () {
+    $owner = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $intruder = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+
+    $detail = assignedDetailFor($owner);
+
+    $this->actingAs($intruder, 'sanctum');
+
+    $this->postJson('/api/product-movements', [
+        'detail_assigned_product_id' => $detail->id,
+        'type' => 'royalty',
+        'quantity' => 5,
+    ])->assertStatus(403);
+
+    expect(AssignedProductMovement::count())->toBe(0);
+    expect((float) $detail->fresh()->royalties_quantity)->toBe(0.0);
+});
+
+it('forbids creating a movement on an assignment from another date', function () {
+    $user = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $this->actingAs($user, 'sanctum');
+
+    $detail = assignedDetailFor($user, ['date' => now()->subDay()]);
+
+    $this->postJson('/api/product-movements', [
+        'detail_assigned_product_id' => $detail->id,
+        'type' => 'royalty',
+        'quantity' => 5,
+    ])->assertStatus(403);
+
+    expect(AssignedProductMovement::count())->toBe(0);
+});
+
+it('forbids deleting a movement that belongs to another employee', function () {
+    $owner = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $intruder = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+
+    $detail = assignedDetailFor($owner);
+
+    $this->actingAs($owner, 'sanctum');
+    $created = $this->postJson('/api/product-movements', [
+        'detail_assigned_product_id' => $detail->id,
+        'type' => 'royalty',
+        'quantity' => 5,
+    ])->assertStatus(201);
+
+    $movementId = $created->json('data.id');
+
+    $this->actingAs($intruder, 'sanctum');
+    $this->deleteJson("/api/product-movements/{$movementId}")->assertStatus(403);
+
+    expect(AssignedProductMovement::find($movementId))->not->toBeNull();
+    expect((float) $detail->fresh()->royalties_quantity)->toBe(5.0);
+});
+
+it('returns 404 when deleting a movement that does not exist', function () {
+    $user = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $this->actingAs($user, 'sanctum');
+
+    $this->deleteJson('/api/product-movements/99999')->assertStatus(404);
+});
+
+it('allows the owner to delete their own movement and reverts the accumulator', function () {
+    $user = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $this->actingAs($user, 'sanctum');
+
+    $detail = assignedDetailFor($user);
+
+    $movementId = $this->postJson('/api/product-movements', [
+        'detail_assigned_product_id' => $detail->id,
+        'type' => 'royalty',
+        'quantity' => 5,
+    ])->json('data.id');
+
+    $this->deleteJson("/api/product-movements/{$movementId}")->assertStatus(200);
+
+    expect(AssignedProductMovement::find($movementId))->toBeNull();
+    expect((float) $detail->fresh()->royalties_quantity)->toBe(0.0);
+    expect((float) $detail->fresh()->stock)->toBe(50.0);
+});

--- a/tests/Feature/AssignedProductStockGuardTest.php
+++ b/tests/Feature/AssignedProductStockGuardTest.php
@@ -1,0 +1,302 @@
+<?php
+
+use App\Models\AssignedProduct;
+use App\Models\Client;
+use App\Models\DetailAssignedProduct;
+use App\Models\Employee;
+use App\Models\Product;
+use App\Models\Sale;
+use App\Models\User;
+use App\Services\AssignedProductMovementService;
+use App\Services\SaleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el sobrante mostrado al vendedor quedaba por debajo del físico
+ * porque la venta validaba contra `quantity` y no contra el sobrante real
+ * (quantity - vendido - devuelto - cambios - regalías).
+ */
+
+function makeAssignedDetail(array $overrides = []): array
+{
+    $employee = Employee::factory()->create();
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $product = Product::factory()->create(['name' => 'Jugo Naranja', 'is_active' => true]);
+    $client = Client::factory()->create();
+
+    $assignedProduct = AssignedProduct::factory()->create([
+        'employee_id' => $employee->id,
+        'date' => now(),
+    ]);
+
+    $detail = DetailAssignedProduct::factory()->create(array_merge([
+        'assigned_products_id' => $assignedProduct->id,
+        'product_id' => $product->id,
+        'quantity' => 80,
+        'sale_quantity' => 0,
+        'returned_quantity' => 0,
+        'changes_quantity' => 0,
+        'royalties_quantity' => 0,
+    ], $overrides));
+
+    return compact('employee', 'user', 'product', 'client', 'assignedProduct', 'detail');
+}
+
+function saleLine(int $productId, float $quantity, ?string $movementType = null): array
+{
+    return [
+        'origin' => 'api',
+        'product_id' => $productId,
+        'name' => 'Jugo Naranja',
+        'type_price_id' => DB::table('types_prices')->insertGetId(['name' => 'Test Price']),
+        'unit_name' => 'Unidad',
+        'quantity' => $quantity,
+        'unit_price_without_tax' => 10,
+        'unit_tax_amount' => 0,
+        'line_subtotal' => 10 * $quantity,
+        'line_tax_amount' => 0,
+        'line_total' => 10 * $quantity,
+        'movement_type' => $movementType,
+    ];
+}
+
+function saleHeader(Employee $employee, Client $client): array
+{
+    return [
+        'client_id' => $client->id,
+        'employee_id' => $employee->id,
+        'sale_date' => now()->toDateString(),
+        'cash_amount' => 0,
+        'payment_method' => 'cash',
+        'payment_term' => 'cash',
+        'branch_id' => 1,
+    ];
+}
+
+// --- Fix 1: la venta debe validar contra el sobrante, no contra lo asignado ---
+
+it('rejects a sale that exceeds the remaining stock once royalties were registered', function () {
+    // Escenario real observado: 80 asignados, 6 salieron como regalía → sólo 74 vendibles.
+    ['user' => $user, 'employee' => $employee, 'client' => $client,
+     'product' => $product, 'detail' => $detail] = makeAssignedDetail(['royalties_quantity' => 6]);
+
+    $this->actingAs($user);
+
+    $service = app(SaleService::class);
+
+    expect(fn () => $service->createSale(
+        saleHeader($employee, $client),
+        [saleLine($product->id, 80)],
+    ))->toThrow(Exception::class, 'excede el sobrante disponible');
+
+    // Antes del fix esto grababa sale_quantity = 80 y dejaba stock = -6
+    expect((float) $detail->fresh()->sale_quantity)->toBe(0.0);
+    expect(Sale::count())->toBe(0);
+});
+
+it('rejects a sale that exceeds the remaining stock once changes were registered', function () {
+    ['user' => $user, 'employee' => $employee, 'client' => $client,
+     'product' => $product, 'detail' => $detail] = makeAssignedDetail(['changes_quantity' => 10]);
+
+    $this->actingAs($user);
+
+    expect(fn () => app(SaleService::class)->createSale(
+        saleHeader($employee, $client),
+        [saleLine($product->id, 75)],
+    ))->toThrow(Exception::class, 'excede el sobrante disponible');
+
+    expect((float) $detail->fresh()->sale_quantity)->toBe(0.0);
+});
+
+it('rejects a sale that exceeds the remaining stock once returns were registered', function () {
+    ['user' => $user, 'employee' => $employee, 'client' => $client,
+     'product' => $product] = makeAssignedDetail(['returned_quantity' => 30]);
+
+    $this->actingAs($user);
+
+    expect(fn () => app(SaleService::class)->createSale(
+        saleHeader($employee, $client),
+        [saleLine($product->id, 51)],
+    ))->toThrow(Exception::class, 'excede el sobrante disponible');
+});
+
+it('allows a sale for exactly the remaining stock after royalties', function () {
+    ['user' => $user, 'employee' => $employee, 'client' => $client,
+     'product' => $product, 'detail' => $detail] = makeAssignedDetail(['royalties_quantity' => 6]);
+
+    $this->actingAs($user);
+
+    $sale = app(SaleService::class)->createSale(
+        saleHeader($employee, $client),
+        [saleLine($product->id, 74)],
+    );
+
+    expect($sale->details)->toHaveCount(1);
+
+    $fresh = $detail->fresh();
+    expect((float) $fresh->sale_quantity)->toBe(74.0);
+    expect((float) $fresh->stock)->toBe(0.0);
+});
+
+it('never leaves negative stock when a royalty and a sale line ship in the same payload', function () {
+    ['user' => $user, 'employee' => $employee, 'client' => $client,
+     'product' => $product, 'detail' => $detail] = makeAssignedDetail();
+
+    $this->actingAs($user);
+
+    // 80 asignados: no se pueden vender 80 y además regalar 6.
+    expect(fn () => app(SaleService::class)->createSale(
+        saleHeader($employee, $client),
+        [
+            saleLine($product->id, 6, 'royalty'),
+            saleLine($product->id, 80),
+        ],
+    ))->toThrow(Exception::class);
+
+    // Todo el createSale es transaccional: ni el movimiento ni la venta quedan grabados
+    $fresh = $detail->fresh();
+    expect((float) $fresh->royalties_quantity)->toBe(0.0);
+    expect((float) $fresh->sale_quantity)->toBe(0.0);
+    expect((float) $fresh->stock)->toBe(80.0);
+    expect(Sale::count())->toBe(0);
+});
+
+// --- Fix 2: el resultado no debe depender del orden del payload ---
+
+it('produces the same result regardless of the order of sale and movement lines', function () {
+    $run = function (array $lines) {
+        ['user' => $user, 'employee' => $employee, 'client' => $client,
+         'product' => $product, 'detail' => $detail] = makeAssignedDetail();
+
+        $this->actingAs($user);
+
+        app(SaleService::class)->createSale(
+            saleHeader($employee, $client),
+            array_map(fn ($line) => saleLine($product->id, $line[0], $line[1]), $lines),
+        );
+
+        $fresh = $detail->fresh();
+
+        return [
+            'sale_quantity' => (float) $fresh->sale_quantity,
+            'royalties_quantity' => (float) $fresh->royalties_quantity,
+            'stock' => (float) $fresh->stock,
+        ];
+    };
+
+    $movementFirst = $run([[6, 'royalty'], [70, null]]);
+    $saleFirst = $run([[70, null], [6, 'royalty']]);
+
+    expect($movementFirst)->toBe($saleFirst)
+        ->and($saleFirst)->toBe([
+            'sale_quantity' => 70.0,
+            'royalties_quantity' => 6.0,
+            'stock' => 4.0,
+        ]);
+});
+
+it('rejects the whole ticket in both orders when sale plus royalty exceed the stock', function () {
+    $attempt = function (array $lines) {
+        ['user' => $user, 'employee' => $employee, 'client' => $client,
+         'product' => $product, 'detail' => $detail] = makeAssignedDetail();
+
+        $this->actingAs($user);
+
+        try {
+            app(SaleService::class)->createSale(
+                saleHeader($employee, $client),
+                array_map(fn ($line) => saleLine($product->id, $line[0], $line[1]), $lines),
+            );
+
+            return 'no-throw';
+        } catch (Exception $e) {
+            $fresh = $detail->fresh();
+
+            return [
+                'sale_quantity' => (float) $fresh->sale_quantity,
+                'royalties_quantity' => (float) $fresh->royalties_quantity,
+            ];
+        }
+    };
+
+    expect($attempt([[6, 'royalty'], [78, null]]))
+        ->toBe(['sale_quantity' => 0.0, 'royalties_quantity' => 0.0])
+        ->and($attempt([[78, null], [6, 'royalty']]))
+        ->toBe(['sale_quantity' => 0.0, 'royalties_quantity' => 0.0]);
+});
+
+it('accumulates sale quantity across consecutive sales without exceeding the remaining stock', function () {
+    ['user' => $user, 'employee' => $employee, 'client' => $client,
+     'product' => $product, 'detail' => $detail] = makeAssignedDetail(['royalties_quantity' => 6]);
+
+    $this->actingAs($user);
+    $service = app(SaleService::class);
+
+    // Clientes distintos por venta: ClientVisitService sólo admite una visita
+    // por cliente y día, lo que es ajeno a este caso de regresión.
+    $service->createSale(saleHeader($employee, $client), [saleLine($product->id, 40)]);
+    $service->createSale(saleHeader($employee, Client::factory()->create()), [saleLine($product->id, 34)]);
+
+    expect((float) $detail->fresh()->sale_quantity)->toBe(74.0);
+
+    expect(fn () => $service->createSale(
+        saleHeader($employee, Client::factory()->create()),
+        [saleLine($product->id, 1)],
+    ))->toThrow(Exception::class, 'excede el sobrante disponible');
+
+    expect((float) $detail->fresh()->stock)->toBe(0.0);
+});
+
+// --- Fix 3: reversión del acumulador al eliminar un movimiento ---
+
+it('reverts the accumulator when a movement is deleted', function () {
+    ['user' => $user, 'detail' => $detail] = makeAssignedDetail();
+    $this->actingAs($user);
+
+    $service = app(AssignedProductMovementService::class);
+    $movement = $service->createMovement($detail->id, 'royalty', 6);
+
+    expect((float) $detail->fresh()->royalties_quantity)->toBe(6.0);
+
+    $service->deleteMovement($movement->id);
+
+    $fresh = $detail->fresh();
+    expect((float) $fresh->royalties_quantity)->toBe(0.0);
+    expect((float) $fresh->stock)->toBe(80.0);
+});
+
+it('never drives an accumulator below zero when reverting a movement', function () {
+    ['user' => $user, 'detail' => $detail] = makeAssignedDetail();
+    $this->actingAs($user);
+
+    $service = app(AssignedProductMovementService::class);
+    $movement = $service->createMovement($detail->id, 'change', 5);
+
+    // Simula un acumulador ya desincronizado (drift histórico) antes de revertir
+    $detail->update(['changes_quantity' => 2]);
+
+    $service->deleteMovement($movement->id);
+
+    expect((float) $detail->fresh()->changes_quantity)->toBe(0.0);
+});
+
+// --- Fix 7: los casts decimales deben estar activos ---
+
+it('casts the assigned product detail accumulators as decimals', function () {
+    ['detail' => $detail] = makeAssignedDetail([
+        'quantity' => 80,
+        'sale_quantity' => 10,
+        'royalties_quantity' => 6,
+    ]);
+
+    $fresh = $detail->fresh();
+
+    expect($fresh->getCasts())->toHaveKey('quantity')
+        ->and($fresh->quantity)->toEqual('80.00')
+        ->and($fresh->sale_quantity)->toEqual('10.00')
+        ->and($fresh->royalties_quantity)->toEqual('6.00')
+        ->and((float) $fresh->stock)->toBe(64.0);
+});


### PR DESCRIPTION
## Problema

El vendedor veía en la app **menos sobrante del que llevaba en físico**.

La causa raíz: `SaleService::createSaleDetails` validaba la cantidad a vender contra `quantity` (lo asignado) en vez de contra el sobrante real, así que dejaba vender unidades que ya habían salido como regalía o cambio.

Caso encontrado en datos (`detail_assigned_products` #308):

```
quantity=80  sale_quantity=80  royalties_quantity=6  →  stock = -6
```

Mientras tanto `AssignedProductMovementService` sí validaba correctamente contra `stock`. Esa asimetría es el bug.

## Cambios

### Control de stock
- La venta valida contra `$detail->stock` (descuenta vendido + devuelto + cambios + regalías). El mensaje de error informa el sobrante disponible.
- Las líneas de venta se procesan **siempre antes** que los movimientos, para que el resultado no dependa del orden en que el móvil arme el payload.

### Concurrencia
- `lockForUpdate()` en `createMovement` y `deleteMovement`. El acumulador se lee y se reescribe; sin bloqueo dos movimientos concurrentes se pisaban y sólo uno quedaba contabilizado.
- La reversión al eliminar un movimiento nunca deja el acumulador por debajo de 0.

### Idempotencia
- Nueva columna `client_request_uuid` (nullable + único) en `assigned_product_movements`, mismo patrón que `sales`.
- `POST /api/product-movements` resuelve la idempotencia antes que cualquier otra validación, y ante colisión concurrente del índice único devuelve el movimiento que sí quedó registrado en vez de reventar.
- Sin este cambio, un reintento del móvil por respuesta perdida registraba la regalía dos veces y bajaba el sobrante.

### Autorización
- `create` y `delete` exigen que el detalle pertenezca a la asignación **del empleado autenticado y del día**. Antes bastaba con que el id existiera: cualquier usuario autenticado podía inflar o borrar el sobrante de otro vendedor.
- `deleteMovement` distingue 404 (no existe) de 403 (existe pero es ajeno).

### Códigos de estado
- Stock insuficiente → **422** en vez de 500, vía `InsufficientAssignedStockException`. Un 500 invita a la app a reintentar un error que reintentar no resuelve.
- `$request->validate()` estaba dentro del `try`, así que toda `ValidationException` se degradaba a 500 y el móvil nunca veía qué campo era inválido.

### Otros
- `DetailAssignedProduct`: `protected $cast` → `$casts`. Los casts `decimal:2` nunca se estaban aplicando.

## Tests

`AssignedProductStockGuardTest` (11) y `AssignedProductMovementApiGuardTest` (10). Suite completa: **66 passed**.

Verifiqué el rojo: sin los cambios de servicio/modelo, 7 de los primeros 9 tests fallan.

Cobertura: el escenario exacto del #308 con rollback verificado, los mismos rechazos con `changes_quantity` y `returned_quantity`, el límite exacto permitido, orden del payload invertido con resultado idéntico, reintento con el mismo uuid, reintento sin uuid, 422 por stock, 403 por asignación ajena, 403 por asignación de otra fecha, 403 al borrar movimiento ajeno, y 404.

## Migración

`2026_08_10_000001_add_client_request_uuid_to_assigned_product_movements_table` — columna nullable con índice único, sin backfill.

## Fuera de alcance (documentado en `docs/devflow/bug-fixes/2026-08-10-assigned-product-movements-known-issues.md`)

- **`ClientVisitService::registerVisit`**: la clave del `updateOrCreate` es más estricta que el índice único real de la tabla. Hoy no se manifiesta porque un cliente no lo tienen dos empleados, pero cuando pase, el fallo hace rollback de la **venta completa**, no sólo de la visita.
- **Movimientos huérfanos al borrar ventas**: el `nullOnDelete()` del `sale_id` deja las regalías desligadas y los acumuladores sin revertir. Se aborda junto con el trabajo de borrado/anulación de ventas.

## Pendiente operativo

El registro `detail_assigned_products` #308 sigue con `stock -6` en producción; este PR impide nuevos casos pero no corrige el dato existente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)