### PR TITLE
feat(sales): anulación de ventas — no más borrado físico

### DIFF
--- a/app/Enums/SaleChannelEnum.php
+++ b/app/Enums/SaleChannelEnum.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Canal de origen de la venta. Es informativo (reportería, UI): la lógica
+ * de reversión de una anulación NUNCA debe decidir por este campo, sino por
+ * evidencia directa (existe AssignedProduct / existen asientos de
+ * management_inventory para la venta). Ver
+ * docs/devflow/specs/2026-08-10-sale-deletion-analysis.md §6.
+ */
+enum SaleChannelEnum: string
+{
+    case APP = 'app';
+    case WEB = 'web';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::APP => 'Aplicación móvil',
+            self::WEB => 'Sitio web',
+        };
+    }
+
+    public static function getOptions(): array
+    {
+        return collect(self::cases())
+            ->mapWithKeys(fn ($case) => [$case->value => $case->getLabel()])
+            ->toArray();
+    }
+}

--- a/app/Exceptions/SaleCancellationException.php
+++ b/app/Exceptions/SaleCancellationException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+/**
+ * Error de negocio (no transitorio) al intentar anular una venta: precondición
+ * no cumplida (R1-R5, factura emitida) o evidencia insuficiente para revertir
+ * con seguridad. El código pasado al constructor es el status HTTP sugerido
+ * para las capas que consuman el servicio (Filament, API), siguiendo el mismo
+ * patrón que el resto del código (`new Exception($msg, 422)`).
+ */
+class SaleCancellationException extends Exception
+{
+}

--- a/app/Filament/Resources/AccountReceivableResource/Widgets/AccountReceivableStatsOverview.php
+++ b/app/Filament/Resources/AccountReceivableResource/Widgets/AccountReceivableStatsOverview.php
@@ -11,16 +11,20 @@ class AccountReceivableStatsOverview extends BaseWidget
 {
     protected function getStats(): array
     {
-        $totalReceivables = AccountReceivable::count();
+        // Las CxC canceladas (venta anulada, sin pagos) no son parte de la
+        // cartera activa: quedan fuera de todos los totales para que un
+        // puñado de anulaciones no infle "Monto Total" ni desinfle el
+        // porcentaje de cobranza con dinero que nunca se iba a cobrar.
+        $totalReceivables = AccountReceivable::notCancelled()->count();
         $pendingReceivables = AccountReceivable::where('status', AccountReceivableStatusEnum::PENDING)->count();
         $paidReceivables = AccountReceivable::where('status', AccountReceivableStatusEnum::PAID)->count();
         $overdueReceivables = AccountReceivable::where('due_date', '<', now())
             ->where('status', AccountReceivableStatusEnum::PENDING)
             ->count();
 
-        $totalAmount = AccountReceivable::sum('total_amount');
+        $totalAmount = AccountReceivable::notCancelled()->sum('total_amount');
         $totalPending = AccountReceivable::where('status', AccountReceivableStatusEnum::PENDING)->sum('remaining_balance');
-        $totalPaid = AccountReceivable::sum('total_amount') - AccountReceivable::sum('remaining_balance');
+        $totalPaid = $totalAmount - AccountReceivable::notCancelled()->sum('remaining_balance');
 
         return [
             Stat::make('Total Cuentas por Cobrar', $totalReceivables)

--- a/app/Filament/Resources/AssignedProductResource/RelationManagers/DetailsRelationManager.php
+++ b/app/Filament/Resources/AssignedProductResource/RelationManagers/DetailsRelationManager.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\AssignedProductResource\RelationManagers;
 
 use App\Enums\TypeInventoryManagementEnum;
 use App\Filament\Support\FilamentNotification;
+use App\Models\AssignedProduct;
 use App\Models\DetailAssignedProduct;
 use App\Models\FinishedProductInventory;
 use App\Services\ManagementInventoryService;
@@ -211,6 +212,7 @@ class DetailsRelationManager extends RelationManager
             type: TypeInventoryManagementEnum::SALIDA->value,
             description: 'Asignación de producto al empleado: ' . $record->assignedProduct->employee->first_name . ' ' . $record->assignedProduct->employee->last_name,
             referenceId: $record->assignedProduct->id,
+            referenceType: AssignedProduct::class,
         );
     }
 
@@ -227,6 +229,7 @@ class DetailsRelationManager extends RelationManager
             type: TypeInventoryManagementEnum::ENTRADA->value,
             description: 'Eliminación de producto asignado al empleado: ' . $record->assignedProduct->employee->first_name . ' ' . $record->assignedProduct->employee->last_name,
             referenceId: $record->assignedProduct->id,
+            referenceType: AssignedProduct::class,
         );
     }
 
@@ -254,6 +257,7 @@ class DetailsRelationManager extends RelationManager
                 type: TypeInventoryManagementEnum::ENTRADA->value,
                 description: 'Ajuste de producto asignado al empleado: ' . $record->assignedProduct->employee->first_name . ' ' . $record->assignedProduct->employee->last_name,
                 referenceId: $record->assignedProduct->id,
+                referenceType: AssignedProduct::class,
             );
         } elseif ($difference < 0) {
             app(ManagementInventoryService::class)->processMovement(
@@ -262,6 +266,7 @@ class DetailsRelationManager extends RelationManager
                 type: TypeInventoryManagementEnum::SALIDA->value,
                 description: 'Ajuste de producto asignado al empleado: ' . $record->assignedProduct->employee->first_name . ' ' . $record->assignedProduct->employee->last_name,
                 referenceId: $record->assignedProduct->id,
+                referenceType: AssignedProduct::class,
             );
         }
     }

--- a/app/Filament/Resources/ManagementInventoryResource.php
+++ b/app/Filament/Resources/ManagementInventoryResource.php
@@ -54,12 +54,16 @@ class ManagementInventoryResource extends Resource
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),
-            ])
-            ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
-                ]),
             ]);
+            // DeleteBulkAction retirado a propósito: management_inventory es un
+            // libro de asientos (igual criterio que sales, ver
+            // docs/devflow/specs/2026-08-10-sale-deletion-analysis.md). Además,
+            // SaleCancellationService::fetchSaleInventoryMovements depende de
+            // estas filas como única evidencia para revertir una venta creada
+            // desde la web — borrar un asiento SALIDA de una venta del mismo día
+            // rompe esa reversión en silencio o la hace caer en el camino
+            // equivocado. Un movimiento incorrecto se corrige con un asiento
+            // compensatorio, no borrándolo.
     }
 
     public static function getRelations(): array

--- a/app/Filament/Resources/SaleResource.php
+++ b/app/Filament/Resources/SaleResource.php
@@ -5,14 +5,21 @@ namespace App\Filament\Resources;
 use App\Enums\PaymentTypeEnum;
 use App\Enums\PaymentTermEnum;
 use App\Enums\SaleStatusEnum;
+use App\Enums\UserRole;
+use App\Exceptions\SaleCancellationException;
 use App\Filament\Resources\SaleResource\Pages;
 use App\Models\Employee;
 use App\Models\Sale;
+use App\Models\User;
+use App\Services\SaleCancellationService;
+use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
 
 class SaleResource extends Resource
 {
@@ -118,6 +125,7 @@ class SaleResource extends Resource
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),
+                static::makeTableCancelAction(),
             ]);
             // DeleteBulkAction retirado: una venta nunca se borra físicamente, se
             // anula (ver docs/devflow/specs/2026-08-10-sale-deletion-analysis.md).
@@ -138,5 +146,95 @@ class SaleResource extends Resource
             'view' => Pages\ViewSale::route('/{record}'),
             'edit' => Pages\EditSale::route('/{record}/edit'),
         ];
+    }
+
+    /**
+     * Acción "Anular" para la tabla de ventas. La lógica compartida con
+     * ViewSale (visibilidad, formulario, manejo de errores) vive en los
+     * métodos estáticos de abajo para no duplicarla entre ambos lugares:
+     * Filament\Tables\Actions\Action y Filament\Actions\Action no comparten
+     * jerarquía, así que cada página construye su propia instancia.
+     */
+    public static function makeTableCancelAction(): Tables\Actions\Action
+    {
+        return Tables\Actions\Action::make('cancel')
+            ->label('Anular')
+            ->icon('heroicon-o-x-circle')
+            ->color('danger')
+            ->modalHeading('Anular venta')
+            ->modalSubmitActionLabel('Anular venta')
+            ->form(fn () => static::cancelActionFormSchema())
+            ->visible(fn (Sale $record) => static::saleCanBeCancelledByCurrentUser($record))
+            ->action(fn (Sale $record, array $data) => static::handleCancelAction($record, $data));
+    }
+
+    /**
+     * Autorización de la anulación (§9 del análisis):
+     * - la venta ya anulada o facturada no se muestra (el resto de las
+     *   precondiciones, R1/R2/R5, las valida el servicio y se comunican por
+     *   notificación, porque dependen de estado que puede cambiar entre que
+     *   se renderiza el botón y se hace clic).
+     * - superadmin/admin: cualquier venta.
+     * - cajero: sólo las que él mismo creó (`created_by`), no las
+     *   atribuidas a su employee_id — ver nota en el análisis sobre la
+     *   inconsistencia de `ListSales::getTableQuery` / `CashierSaleScope`.
+     */
+    public static function saleCanBeCancelledByCurrentUser(Sale $record): bool
+    {
+        /** @var User|null $user */
+        $user = Auth::user();
+
+        if (!$user || $record->isCancelled() || $record->isInvoiced()) {
+            return false;
+        }
+
+        if (!$user->can('delete', $record)) {
+            return false;
+        }
+
+        $isPrivileged = $user->hasAnyRole([UserRole::ADMIN->value, UserRole::SUPERADMIN->value]);
+
+        if (!$isPrivileged && $user->hasRole(UserRole::CASHEER->value)) {
+            return $record->created_by === $user->id;
+        }
+
+        return true;
+    }
+
+    public static function cancelActionFormSchema(): array
+    {
+        return [
+            Forms\Components\Placeholder::make('cash_amount_warning')
+                ->label('Atención')
+                ->content(fn (Sale $record) => sprintf(
+                    'Esta venta a crédito tiene un abono inicial de L %s. Ese monto no genera un pago registrado; recuerde devolverlo al cliente.',
+                    number_format((float) $record->cash_amount, 2)
+                ))
+                ->visible(fn (Sale $record) => $record->payment_term === PaymentTermEnum::CREDIT
+                    && (float) $record->cash_amount > 0),
+            Forms\Components\Textarea::make('reason')
+                ->label('Motivo de la anulación')
+                ->required()
+                ->maxLength(500)
+                ->rows(3),
+        ];
+    }
+
+    public static function handleCancelAction(Sale $record, array $data): void
+    {
+        try {
+            app(SaleCancellationService::class)->cancel($record, $data['reason']);
+
+            Notification::make()
+                ->title('Venta anulada correctamente')
+                ->success()
+                ->send();
+        } catch (SaleCancellationException $e) {
+            Notification::make()
+                ->title('No se pudo anular la venta')
+                ->body($e->getMessage())
+                ->danger()
+                ->send();
+        }
     }
 }

--- a/app/Filament/Resources/SaleResource.php
+++ b/app/Filament/Resources/SaleResource.php
@@ -118,12 +118,9 @@ class SaleResource extends Resource
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),
-            ])
-            ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make()
-                ]),
             ]);
+            // DeleteBulkAction retirado: una venta nunca se borra físicamente, se
+            // anula (ver docs/devflow/specs/2026-08-10-sale-deletion-analysis.md).
     }
 
     public static function getRelations(): array

--- a/app/Filament/Resources/SaleResource/Pages/EditSale.php
+++ b/app/Filament/Resources/SaleResource/Pages/EditSale.php
@@ -12,9 +12,10 @@ class EditSale extends EditRecord
 
     protected function getHeaderActions(): array
     {
+        // DeleteAction retirado: una venta nunca se borra físicamente, se anula
+        // (ver docs/devflow/specs/2026-08-10-sale-deletion-analysis.md).
         return [
             Actions\ViewAction::make(),
-            Actions\DeleteAction::make(),
         ];
     }
 }

--- a/app/Filament/Resources/SaleResource/Pages/ViewSale.php
+++ b/app/Filament/Resources/SaleResource/Pages/ViewSale.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\SaleResource\Pages;
 
 use App\Filament\Resources\SaleResource;
+use App\Models\Sale;
 use Filament\Actions;
 use Filament\Infolists\Components\Group;
 use Filament\Infolists\Components\Section;
@@ -20,7 +21,22 @@ class ViewSale extends ViewRecord
 
     protected function getHeaderActions(): array
     {
-        return [];
+        return [
+            Actions\Action::make('cancel')
+                ->label('Anular')
+                ->icon('heroicon-o-x-circle')
+                ->color('danger')
+                ->modalHeading('Anular venta')
+                ->modalSubmitActionLabel('Anular venta')
+                ->form(fn () => SaleResource::cancelActionFormSchema())
+                ->visible(fn (Sale $record) => SaleResource::saleCanBeCancelledByCurrentUser($record))
+                ->action(function (Sale $record, array $data) {
+                    SaleResource::handleCancelAction($record, $data);
+                })
+                // Recarga completa: el infolist lee del $record cargado al
+                // montar la página, que no se actualiza solo tras la acción.
+                ->after(fn () => redirect(static::getResource()::getUrl('view', ['record' => $this->record]))),
+        ];
     }
 
     public function infolist(Infolist $infolist): Infolist
@@ -187,6 +203,24 @@ class ViewSale extends ViewRecord
                         ])
                         ->collapsible()
                         ->collapsed(),
+
+                    Section::make('Anulación')
+                        ->schema([
+                            Grid::make(2)
+                                ->schema([
+                                    TextEntry::make('cancelledBy.name')
+                                        ->label('Anulada por'),
+
+                                    TextEntry::make('cancelled_at')
+                                        ->label('Fecha de anulación')
+                                        ->dateTime('d/m/Y H:i'),
+
+                                    TextEntry::make('cancellation_reason')
+                                        ->label('Motivo')
+                                        ->columnSpanFull(),
+                                ])
+                        ])
+                        ->visible(fn (Sale $record) => $record->isCancelled()),
                 ])
             ]);
     }

--- a/app/Filament/Widgets/SalesRankingWidget.php
+++ b/app/Filament/Widgets/SalesRankingWidget.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Widgets;
 
+use App\Enums\SaleStatusEnum;
 use App\Models\Employee;
 use App\Models\Sale;
 use Filament\Tables;
@@ -46,7 +47,17 @@ class SalesRankingWidget extends BaseWidget
                         DB::raw('COALESCE(SUM(CASE WHEN sales.payment_method = "cash" THEN sales.total_amount ELSE 0 END), 0) as cash_sales'),
                         DB::raw('COALESCE(SUM(CASE WHEN sales.payment_method = "deposit" THEN sales.total_amount ELSE 0 END), 0) as deposit_sales'),
                     ])
-                    ->leftJoin('sales', 'employees.id', '=', 'sales.employee_id')
+                    // Ventas anuladas fuera del ranking. Se filtra dentro del ON (no en
+                    // un WHERE posterior) para no perder los empleados sin ventas: con
+                    // left join, sales.status es NULL en esas filas y un WHERE normal
+                    // las descartaría.
+                    ->leftJoin('sales', function ($join) {
+                        $join->on('employees.id', '=', 'sales.employee_id')
+                            ->where(function ($query) {
+                                $query->where('sales.status', '!=', SaleStatusEnum::CANCELLED->value)
+                                    ->orWhereNull('sales.status');
+                            });
+                    })
                     ->groupBy('employees.id', 'employees.first_name', 'employees.last_name', 'employees.created_at', 'employees.updated_at')
                     ->orderBy('total_amount', 'desc')
             )

--- a/app/Filament/Widgets/SalesRankingWidget.php
+++ b/app/Filament/Widgets/SalesRankingWidget.php
@@ -2,7 +2,6 @@
 
 namespace App\Filament\Widgets;
 
-use App\Enums\SaleStatusEnum;
 use App\Models\Employee;
 use App\Models\Sale;
 use Filament\Tables;
@@ -54,7 +53,7 @@ class SalesRankingWidget extends BaseWidget
                     ->leftJoin('sales', function ($join) {
                         $join->on('employees.id', '=', 'sales.employee_id')
                             ->where(function ($query) {
-                                $query->where('sales.status', '!=', SaleStatusEnum::CANCELLED->value)
+                                $query->where('sales.status', '!=', Sale::cancelledStatusValue())
                                     ->orWhereNull('sales.status');
                             });
                     })

--- a/app/Filament/Widgets/StatsOverview.php
+++ b/app/Filament/Widgets/StatsOverview.php
@@ -10,6 +10,7 @@ use App\Models\Sale;
 use App\Models\AccountReceivable;
 use App\Models\FinishedProductInventory;
 use App\Models\RawMaterialsInventory;
+use App\Enums\SaleStatusEnum;
 use App\Enums\UserRole;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -45,7 +46,8 @@ class StatsOverview extends BaseWidget
             ->count();
 
         // Ventas del mes actual
-        $currentMonthSales = Sale::whereMonth('sale_date', now()->month)
+        $currentMonthSales = Sale::notCancelled()
+            ->whereMonth('sale_date', now()->month)
             ->whereYear('sale_date', now()->year)
             ->sum('total_amount');
 
@@ -55,10 +57,14 @@ class StatsOverview extends BaseWidget
             ->sum('remaining_balance');
 
         // Empleado destacado del mes
+        // whereMonth/whereYear sobre sales.sale_date ya excluyen las filas NULL del
+        // left join (empleados sin ventas), así que un where plano sobre status
+        // es seguro aquí: no hay riesgo de perder empleados por NULL != 'cancelled'.
         $topEmployee = Employee::select('employees.first_name', 'employees.last_name')
             ->leftJoin('sales', 'employees.id', '=', 'sales.employee_id')
             ->whereMonth('sales.sale_date', now()->month)
             ->whereYear('sales.sale_date', now()->year)
+            ->where('sales.status', '!=', SaleStatusEnum::CANCELLED->value)
             ->groupBy('employees.id', 'employees.first_name', 'employees.last_name')
             ->orderBy(DB::raw('SUM(sales.total_amount)'), 'desc')
             ->first();

--- a/app/Filament/Widgets/StatsOverview.php
+++ b/app/Filament/Widgets/StatsOverview.php
@@ -10,7 +10,6 @@ use App\Models\Sale;
 use App\Models\AccountReceivable;
 use App\Models\FinishedProductInventory;
 use App\Models\RawMaterialsInventory;
-use App\Enums\SaleStatusEnum;
 use App\Enums\UserRole;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -64,7 +63,7 @@ class StatsOverview extends BaseWidget
             ->leftJoin('sales', 'employees.id', '=', 'sales.employee_id')
             ->whereMonth('sales.sale_date', now()->month)
             ->whereYear('sales.sale_date', now()->year)
-            ->where('sales.status', '!=', SaleStatusEnum::CANCELLED->value)
+            ->where('sales.status', '!=', Sale::cancelledStatusValue())
             ->groupBy('employees.id', 'employees.first_name', 'employees.last_name')
             ->orderBy(DB::raw('SUM(sales.total_amount)'), 'desc')
             ->first();

--- a/app/Http/Controllers/AccountReceivableController.php
+++ b/app/Http/Controllers/AccountReceivableController.php
@@ -37,6 +37,7 @@ class AccountReceivableController extends Controller
     {
         try {
             $accountReceivable = AccountReceivable::byEmployee(Auth::user()->employee_id)
+                ->notCancelled()
                 ->where(function($query) {
                     $query->whereNull('paid_at')
                         ->orWhere(function($sub) {
@@ -129,6 +130,7 @@ class AccountReceivableController extends Controller
             $date = $request->query('date', Carbon::now()->toDateString());
 
             $accountsWithPayments = AccountReceivable::byEmployee(Auth::user()->employee_id)
+                ->notCancelled()
                 ->with(['payments' => function($query) use ($date) {
                     $query->whereDate('payment_date', $date);
                 }])

--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\PaymentTermEnum;
 use App\Exceptions\InsufficientAssignedStockException;
+use App\Exceptions\SaleCancellationException;
 use App\Http\Requests\SaleRequest;
 use App\Http\Resources\SaleDetailResource;
 use App\Http\Resources\SaleResource;
@@ -15,6 +17,7 @@ use App\Models\SaleDetail;
 use App\Services\AccountReceivableService;
 use App\Services\AssignedProductMovementService;
 use App\Services\ManagementInventoryService;
+use App\Services\SaleCancellationService;
 use App\Services\SaleService;
 use App\Traits\ApiResponse;
 use Carbon\Carbon;
@@ -28,6 +31,7 @@ class SaleController extends Controller
     use ApiResponse;
 
     private $saleService;
+    private $saleCancellationService;
 
     public function __construct()
     {
@@ -36,6 +40,11 @@ class SaleController extends Controller
             new AccountReceivableService(),
             new ClientVisitService(),
             new AssignedProductMovementService()
+        );
+
+        $this->saleCancellationService = new SaleCancellationService(
+            new AssignedProductMovementService(),
+            new ManagementInventoryService()
         );
     }
 
@@ -162,6 +171,76 @@ class SaleController extends Controller
                 $exc->getCode() ?: 500,
                 "Ocurrió un error al obtener el detalle de la venta"
             );
+        }
+    }
+
+    /**
+     * Anula una venta (app móvil). Sólo el vendedor dueño de la venta puede
+     * anularla, la misma restricción del vendedor en Filament (§9 del
+     * análisis) — el admin/cajero anulan desde el panel web, no por esta ruta.
+     *
+     * Idempotente: si la venta ya está anulada, responde 200 igual que una
+     * anulación exitosa (SaleCancellationService::cancel no lanza en ese
+     * caso), para que un reintento de la cola offline del móvil no se
+     * atasque con un error.
+     *
+     * @param int $id
+     * @return JsonResponse
+     */
+    public function cancelSale(Request $request, int $id): JsonResponse
+    {
+        // El motivo es opcional en este canal (a diferencia de Filament,
+        // donde es obligatorio para todos los roles): el vendedor suele
+        // anular al instante por un error de captura, sin fricción extra.
+        $request->validate([
+            'reason' => 'nullable|string|max:500',
+        ]);
+
+        try {
+            $sale = Sale::find($id);
+
+            if (!$sale) {
+                return $this->errorResponse(
+                    new Exception('Venta no encontrada.'),
+                    404,
+                    'Venta no encontrada.'
+                );
+            }
+
+            if ($sale->employee_id !== Auth::user()->employee_id) {
+                return $this->errorResponse(
+                    new Exception('La venta no pertenece al vendedor autenticado.'),
+                    403,
+                    'No autorizado para anular esta venta.'
+                );
+            }
+
+            $cancelled = $this->saleCancellationService->cancel($sale, $request->input('reason'));
+
+            // R6: aviso de devolución cuando la venta a crédito llevó abono
+            // inicial (no genera fila en payments, así que el chequeo de R5
+            // no lo detecta y la anulación sí procede).
+            $cashToReturn = null;
+            if ($cancelled->payment_term === PaymentTermEnum::CREDIT && (float) $cancelled->cash_amount > 0) {
+                $cashToReturn = (float) $cancelled->cash_amount;
+            }
+
+            $message = "Venta #INV-{$cancelled->id} anulada correctamente.";
+            if ($cashToReturn !== null) {
+                $message .= sprintf(' Recuerde devolver L %s al cliente.', number_format($cashToReturn, 2));
+            }
+
+            return $this->successResponse([
+                'id' => $cancelled->id,
+                'status' => $cancelled->status->value,
+                'cash_to_return' => $cashToReturn,
+            ], $message);
+
+        } catch (SaleCancellationException $e) {
+            return $this->errorResponse($e, $e->getCode() ?: 422, $e->getMessage());
+
+        } catch (Exception $e) {
+            return $this->errorResponse($e, 500, 'Error al anular la venta.');
         }
     }
 

--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -124,6 +124,7 @@ class SaleController extends Controller
             $date = $request->query('date');
 
             $sales = Sale::toDay($date)
+                ->notCancelled()
                 ->where('employee_id', Auth::user()->employee_id)
                 ->with([
                     'client:id,first_name,last_name,business_name',

--- a/app/Livewire/Reconciliations/CreateReconciliation.php
+++ b/app/Livewire/Reconciliations/CreateReconciliation.php
@@ -206,6 +206,7 @@ class CreateReconciliation extends Component
 
         // Load sales for the selected date and employee
         $this->sales = Sale::with(['client'])
+            ->notCancelled()
             ->where('employee_id', $this->employee_id)
             ->whereDate('sale_date', $selectedDate)
             ->get()

--- a/app/Livewire/Sales/CreateSale.php
+++ b/app/Livewire/Sales/CreateSale.php
@@ -443,9 +443,12 @@ class CreateSale extends Component
     public function save(): void
     {
         // Validation
+        // sale_date no se valida como entrada editable: la fecha de venta la fija
+        // el servidor (ver R7 en docs/devflow/specs/2026-08-10-sale-deletion-analysis.md).
+        // Un campo readonly en el HTML no impide que un cliente Livewire manipulado
+        // envíe otro valor, así que se ignora explícitamente más abajo.
         $this->validate([
             'employee_id' => 'required|exists:employees,id',
-            'sale_date' => 'required|date',
             'payment_method' => 'required|string',
             'payment_term' => 'required|string|in:' . implode(',', array_column(PaymentTermEnum::cases(), 'value')),
             'amount_paid' => 'required|numeric|min:0',
@@ -476,7 +479,7 @@ class CreateSale extends Component
             $sale = Sale::create([
                 'client_id' => $this->client_id,
                 'employee_id' => $this->employee_id,
-                'sale_date' => $this->sale_date,
+                'sale_date' => now(),
                 'subtotal' => $subtotal,
                 'total_amount' => $final_total,
                 'payment_method' => PaymentTypeEnum::from($payment_type),

--- a/app/Livewire/Sales/CreateSale.php
+++ b/app/Livewire/Sales/CreateSale.php
@@ -524,6 +524,7 @@ class CreateSale extends Component
                         \App\Enums\TypeInventoryManagementEnum::SALIDA->value,
                         'Venta de producto: ' . $item['name'],
                         $sale->id,
+                        Sale::class,
                     );
                 }
             }

--- a/app/Models/AccountReceivable.php
+++ b/app/Models/AccountReceivable.php
@@ -75,4 +75,13 @@ class AccountReceivable extends Model
     {
         return $query->where('status', AccountReceivableStatusEnum::PAID);
     }
+
+    /**
+     * Excluye cuentas por cobrar canceladas (venta anulada, sin pagos). Usar en
+     * cualquier consulta que liste o cuente cuentas activas del cliente/vendedor.
+     */
+    public function scopeNotCancelled($query)
+    {
+        return $query->where('status', '!=', AccountReceivableStatusEnum::CANCELLED);
+    }
 }

--- a/app/Models/ManagementInventory.php
+++ b/app/Models/ManagementInventory.php
@@ -19,6 +19,7 @@ class ManagementInventory extends Model
         'model_type',
         'model_id',
         'reference_id',
+        'reference_type',
         'created_by'
     ];
 

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -131,6 +131,16 @@ class Sale extends Model
         return $query->where('status', SaleStatusEnum::CANCELLED);
     }
 
+    /**
+     * Excluye ventas anuladas. Usar en cualquier consulta que sume o liste ventas
+     * (cuadres, reportes, rankings, listados de la app) para que una venta anulada
+     * deje de contar en todos lados.
+     */
+    public function scopeNotCancelled($query)
+    {
+        return $query->where('status', '!=', SaleStatusEnum::CANCELLED);
+    }
+
     public function scopeByDateRange($query, $startDate, $endDate)
     {
         return $query->whereBetween('sale_date', [$startDate, $endDate]);

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\SaleStatusEnum;
+use App\Enums\SaleChannelEnum;
 use App\Enums\PaymentTypeEnum;
 use App\Enums\PaymentTermEnum;
 use App\Models\Scopes\CashierSaleScope;
@@ -22,6 +23,7 @@ class Sale extends Model
         'invoice_series_id',
         'client_id',
         'employee_id',
+        'branch_id',
         'deposit_id',
         'sale_date',
         'due_date',
@@ -29,6 +31,7 @@ class Sale extends Model
         'payment_term',
         'payment_method',
         'cash_amount',
+        'payment_reference',
         'subtotal',
         'discount_percentage',
         'discount_amount',
@@ -36,16 +39,22 @@ class Sale extends Model
         'total_amount',
         'notes',
         'client_request_uuid',
+        'channel',
         'created_by',
         'updated_by',
         'confirmed_at',
+        'cancelled_at',
+        'cancelled_by',
+        'cancellation_reason',
     ];
 
     protected $casts = [
         'sale_date' => 'date',
         'due_date' => 'date',
         'confirmed_at' => 'datetime',
+        'cancelled_at' => 'datetime',
         'status' => SaleStatusEnum::class,
+        'channel' => SaleChannelEnum::class,
         'payment_term' => PaymentTermEnum::class,
         'payment_method' => PaymentTypeEnum::class,
         'subtotal' => 'decimal:4',
@@ -65,6 +74,11 @@ class Sale extends Model
         return $this->belongsTo(Employee::class);
     }
 
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
+    }
+
     public function invoiceSeries(): BelongsTo
     {
         return $this->belongsTo(InvoicesSeries::class, 'invoice_series_id');
@@ -78,6 +92,11 @@ class Sale extends Model
     public function updatedBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'updated_by');
+    }
+
+    public function cancelledBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'cancelled_by');
     }
 
     public function details(): HasMany

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -160,6 +160,17 @@ class Sale extends Model
         return $query->where('status', '!=', SaleStatusEnum::CANCELLED);
     }
 
+    /**
+     * Valor de "anulada" para queries SQL crudas (joins manuales, whereRaw)
+     * que no pueden aplicar scopeNotCancelled() por no ser un query builder
+     * de Eloquent sobre Sale (p. ej. un leftJoin desde Employee). Único
+     * lugar a actualizar si el criterio de "cancelada" cambia.
+     */
+    public static function cancelledStatusValue(): string
+    {
+        return SaleStatusEnum::CANCELLED->value;
+    }
+
     public function scopeByDateRange($query, $startDate, $endDate)
     {
         return $query->whereBetween('sale_date', [$startDate, $endDate]);

--- a/app/Services/ManagementInventoryService.php
+++ b/app/Services/ManagementInventoryService.php
@@ -18,6 +18,9 @@ class ManagementInventoryService
      * @param string $type El tipo de movimiento (entrada, salida, dañado, devolución)
      * @param string $description Descripción del movimiento
      * @param int|null $referenceId ID de referencia opcional
+     * @param class-string|null $referenceType Clase del modelo al que pertenece $referenceId
+     *        (p. ej. Sale::class, ProductReturn::class, AssignedProduct::class). Sin esto,
+     *        reference_id es ambiguo entre orígenes distintos que reutilizan el mismo id.
      * @return ManagementInventory El registro creado
      * @throws \InvalidArgumentException Si el tipo de movimiento no es válido
      */
@@ -26,15 +29,16 @@ class ManagementInventoryService
         float $quantity,
         string $type,
         string $description,
-        ?int $referenceId = null
+        ?int $referenceId = null,
+        ?string $referenceType = null
     ): ManagementInventory {
         if ($quantity <= 0) throw new \InvalidArgumentException('La cantidad debe ser mayor que cero');
 
         return match ($type) {
-            TypeInventoryManagementEnum::ENTRADA->value => $this->registerEntry($model, $quantity, $description, $referenceId),
-            TypeInventoryManagementEnum::SALIDA->value => $this->registerExit($model, $quantity, $description, $referenceId),
-            TypeInventoryManagementEnum::DANADO->value => $this->registerDamaged($model, $quantity, $description, $referenceId),
-            TypeInventoryManagementEnum::DEVOLUCION->value => $this->registerReturn($model, $quantity, $description, $referenceId),
+            TypeInventoryManagementEnum::ENTRADA->value => $this->registerEntry($model, $quantity, $description, $referenceId, $referenceType),
+            TypeInventoryManagementEnum::SALIDA->value => $this->registerExit($model, $quantity, $description, $referenceId, $referenceType),
+            TypeInventoryManagementEnum::DANADO->value => $this->registerDamaged($model, $quantity, $description, $referenceId, $referenceType),
+            TypeInventoryManagementEnum::DEVOLUCION->value => $this->registerReturn($model, $quantity, $description, $referenceId, $referenceType),
             default => throw new \InvalidArgumentException('Tipo de movimiento de inventario no válido: ' . $type),
         };
     }
@@ -47,6 +51,7 @@ class ManagementInventoryService
      * @param TypeInventoryManagementEnum $type El tipo de movimiento (entrada, salida, dañado, devolución)
      * @param string $description Descripción del movimiento
      * @param int|null $referenceId ID de referencia opcional (ej: ID de factura, orden, etc.)
+     * @param class-string|null $referenceType Clase del modelo al que pertenece $referenceId
      * @return ManagementInventory El registro creado
      */
     protected function registerMovement(
@@ -54,7 +59,8 @@ class ManagementInventoryService
         float $quantity,
         TypeInventoryManagementEnum $type,
         string $description,
-        ?int $referenceId = null
+        ?int $referenceId = null,
+        ?string $referenceType = null
     ): ManagementInventory {
         if (!method_exists($model, 'movements')) throw new \RuntimeException('El modelo no tiene una relación "movements" definida');
 
@@ -63,6 +69,7 @@ class ManagementInventoryService
             'quantity' => $quantity,
             'type' => $type->value,
             'reference_id' => $referenceId,
+            'reference_type' => $referenceType,
             'created_by' => Auth::user()->name,
         ]);
     }
@@ -74,15 +81,17 @@ class ManagementInventoryService
      * @param float $quantity La cantidad a incrementar
      * @param string $description Descripción de la entrada
      * @param int|null $referenceId ID de referencia opcional
+     * @param class-string|null $referenceType Clase del modelo al que pertenece $referenceId
      * @return ManagementInventory El registro creado
      */
     public function registerEntry(
         Model $model,
         float $quantity,
         string $description,
-        ?int $referenceId = null
+        ?int $referenceId = null,
+        ?string $referenceType = null
     ): ManagementInventory {
-        return DB::transaction(function () use ($model, $quantity, $description, $referenceId) {
+        return DB::transaction(function () use ($model, $quantity, $description, $referenceId, $referenceType) {
             DB::table($model->getTable())
                 ->where('id', $model->id)
                 ->increment('stock', $quantity);
@@ -92,7 +101,8 @@ class ManagementInventoryService
                 $quantity,
                 TypeInventoryManagementEnum::ENTRADA,
                 $description,
-                $referenceId
+                $referenceId,
+                $referenceType
             );
         });
     }
@@ -104,15 +114,17 @@ class ManagementInventoryService
      * @param float $quantity La cantidad a decrementar
      * @param string $description Descripción de la salida
      * @param int|null $referenceId ID de referencia opcional
+     * @param class-string|null $referenceType Clase del modelo al que pertenece $referenceId
      * @return ManagementInventory El registro creado
      */
     public function registerExit(
         Model $model,
         float $quantity,
         string $description,
-        ?int $referenceId = null
+        ?int $referenceId = null,
+        ?string $referenceType = null
     ): ManagementInventory {
-        return DB::transaction(function () use ($model, $quantity, $description, $referenceId) {
+        return DB::transaction(function () use ($model, $quantity, $description, $referenceId, $referenceType) {
             $affected = DB::table($model->getTable())
                 ->where('id', $model->id)
                 ->where('stock', '>=', $quantity)
@@ -128,7 +140,8 @@ class ManagementInventoryService
                 $quantity,
                 TypeInventoryManagementEnum::SALIDA,
                 $description,
-                $referenceId
+                $referenceId,
+                $referenceType
             );
         });
     }
@@ -140,15 +153,17 @@ class ManagementInventoryService
      * @param float $quantity La cantidad dañada
      * @param string $description Descripción del daño
      * @param int|null $referenceId ID de referencia opcional
+     * @param class-string|null $referenceType Clase del modelo al que pertenece $referenceId
      * @return ManagementInventory El registro creado
      */
     public function registerDamaged(
         Model $model,
         float $quantity,
         string $description,
-        ?int $referenceId = null
+        ?int $referenceId = null,
+        ?string $referenceType = null
     ): ManagementInventory {
-        return DB::transaction(function () use ($model, $quantity, $description, $referenceId) {
+        return DB::transaction(function () use ($model, $quantity, $description, $referenceId, $referenceType) {
             $affected = DB::table($model->getTable())
                 ->where('id', $model->id)
                 ->where('stock', '>=', $quantity)
@@ -164,7 +179,8 @@ class ManagementInventoryService
                 $quantity,
                 TypeInventoryManagementEnum::DANADO,
                 $description,
-                $referenceId
+                $referenceId,
+                $referenceType
             );
         });
     }
@@ -176,15 +192,17 @@ class ManagementInventoryService
      * @param float $quantity La cantidad devuelta
      * @param string $description Descripción de la devolución
      * @param int|null $referenceId ID de referencia opcional
+     * @param class-string|null $referenceType Clase del modelo al que pertenece $referenceId
      * @return ManagementInventory El registro creado
      */
     public function registerReturn(
         Model $model,
         float $quantity,
         string $description,
-        ?int $referenceId = null
+        ?int $referenceId = null,
+        ?string $referenceType = null
     ): ManagementInventory {
-        return DB::transaction(function () use ($model, $quantity, $description, $referenceId) {
+        return DB::transaction(function () use ($model, $quantity, $description, $referenceId, $referenceType) {
             DB::table($model->getTable())
                 ->where('id', $model->id)
                 ->increment('stock', $quantity);
@@ -194,7 +212,8 @@ class ManagementInventoryService
                 $quantity,
                 TypeInventoryManagementEnum::DEVOLUCION,
                 $description,
-                $referenceId
+                $referenceId,
+                $referenceType
             );
         });
     }

--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -19,12 +19,24 @@ class PaymentService
     public static function processPayment(AccountReceivable $accountReceivable, array $paymentData): array
     {
         try {
-            self::validatePaymentAmount($accountReceivable, $paymentData['amount']);
-            
             $payment = DB::transaction(function () use ($accountReceivable, $paymentData) {
-                $newBalance = $accountReceivable->remaining_balance - $paymentData['amount'];
-                
-                $payment = $accountReceivable->payments()->create([
+                // Se relee y bloquea dentro de la transacción: el objeto
+                // recibido por parámetro puede estar desactualizado (p. ej.
+                // SaleCancellationService pudo anular la cuenta justo
+                // después de que el controlador la cargara, fuera de esta
+                // transacción). lockForUpdate() serializa contra esa misma
+                // fila que SaleCancellationService también bloquea, así que
+                // exactamente una de las dos operaciones gana la carrera y
+                // la otra ve el estado ya actualizado.
+                $locked = AccountReceivable::whereKey($accountReceivable->id)
+                    ->lockForUpdate()
+                    ->firstOrFail();
+
+                self::validatePaymentAmount($locked, $paymentData['amount']);
+
+                $newBalance = $locked->remaining_balance - $paymentData['amount'];
+
+                $payment = $locked->payments()->create([
                     'amount' => $paymentData['amount'],
                     'balance_after_payment' => max(0, $newBalance),
                     'payment_date' => $paymentData['payment_date'],
@@ -33,7 +45,7 @@ class PaymentService
                 ]);
 
                 // Actualizar el saldo de la cuenta por cobrar
-                $accountReceivable->update([
+                $locked->update([
                     'remaining_balance' => max(0, $newBalance),
                     'status' => $newBalance <= 0 ? AccountReceivableStatusEnum::PAID : AccountReceivableStatusEnum::PENDING,
                     'paid_at' => $newBalance <= 0 ? now() : null,

--- a/app/Services/ProductReturnService.php
+++ b/app/Services/ProductReturnService.php
@@ -62,7 +62,8 @@ class ProductReturnService
                 quantity: $productReturn->quantity,
                 type: $movementType,
                 description: $description,
-                referenceId: $productReturn->id
+                referenceId: $productReturn->id,
+                referenceType: ProductReturn::class,
             );
 
             Log::info('Movimiento de inventario registrado exitosamente', [
@@ -122,7 +123,8 @@ class ProductReturnService
                 $productReturn->quantity,
                 $movementType->value,
                 $description,
-                $productReturn->id
+                $productReturn->id,
+                ProductReturn::class,
             );
 
             Log::info('Movimiento de inventario revertido exitosamente', [

--- a/app/Services/SaleCancellationService.php
+++ b/app/Services/SaleCancellationService.php
@@ -6,6 +6,7 @@ use App\Enums\AccountReceivableStatusEnum;
 use App\Enums\SaleStatusEnum;
 use App\Enums\TypeInventoryManagementEnum;
 use App\Exceptions\SaleCancellationException;
+use App\Models\AccountReceivable;
 use App\Models\AssignedProduct;
 use App\Models\DailySalesReconciliation;
 use App\Models\DetailAssignedProduct;
@@ -59,14 +60,25 @@ class SaleCancellationService
                 return $sale;
             }
 
-            $this->assertCanBeCancelled($sale);
+            // Se bloquea aquí y se reutiliza la misma instancia para el
+            // chequeo de R5 y para cancelarla más abajo: sin esto, un pago
+            // concurrente podía colarse entre el "no tiene pagos" y el
+            // UPDATE a CANCELLED (PaymentService::processPayment nunca
+            // bloquea la fila), dejando una CxC anulada con un pago real
+            // adjunto. lockForUpdate aquí basta — cualquier UPDATE de otra
+            // transacción sobre la misma fila espera a que esta termine.
+            $accountReceivable = AccountReceivable::where('sales_id', $sale->id)
+                ->lockForUpdate()
+                ->first();
+
+            $this->assertCanBeCancelled($sale, $accountReceivable);
 
             $inventoryMovements = $this->fetchSaleInventoryMovements($sale);
 
             $this->revertAssignedProductMovements($sale);
             $this->revertAssignedProductSaleQuantity($sale, $inventoryMovements);
             $this->revertInventoryMovements($sale, $inventoryMovements);
-            $this->cancelAccountReceivableIfCredit($sale);
+            $this->cancelAccountReceivableIfCredit($accountReceivable);
 
             $sale->update([
                 'status' => SaleStatusEnum::CANCELLED,
@@ -79,7 +91,7 @@ class SaleCancellationService
         });
     }
 
-    private function assertCanBeCancelled(Sale $sale): void
+    private function assertCanBeCancelled(Sale $sale, ?AccountReceivable $accountReceivable): void
     {
         if ($sale->isInvoiced()) {
             throw new SaleCancellationException(
@@ -114,7 +126,6 @@ class SaleCancellationService
 
         // R5: cualquier pago registrado bloquea. cash_amount (abono inicial,
         // R6) NO se considera aquí a propósito: no genera fila en payments.
-        $accountReceivable = $sale->accountReceivable;
         if ($accountReceivable && $accountReceivable->payments()->exists()) {
             throw new SaleCancellationException(
                 'La venta tiene pagos registrados sobre su cuenta por cobrar; no se puede anular.',
@@ -268,12 +279,13 @@ class SaleCancellationService
 
     /**
      * R4: venta a crédito con cuenta por cobrar sin pagos (ya validado en
-     * assertCanBeCancelled) → se cancela la CxC. No se borra: queda como
-     * evidencia junto a la venta anulada.
+     * assertCanBeCancelled, contra esta misma instancia bloqueada) → se
+     * cancela la CxC. No se borra: queda como evidencia junto a la venta
+     * anulada.
      */
-    private function cancelAccountReceivableIfCredit(Sale $sale): void
+    private function cancelAccountReceivableIfCredit(?AccountReceivable $accountReceivable): void
     {
-        $sale->accountReceivable?->update([
+        $accountReceivable?->update([
             'status' => AccountReceivableStatusEnum::CANCELLED,
             'cancelled_at' => now(),
         ]);

--- a/app/Services/SaleCancellationService.php
+++ b/app/Services/SaleCancellationService.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\AccountReceivableStatusEnum;
+use App\Enums\SaleStatusEnum;
+use App\Enums\TypeInventoryManagementEnum;
+use App\Exceptions\SaleCancellationException;
+use App\Models\AssignedProduct;
+use App\Models\DailySalesReconciliation;
+use App\Models\DetailAssignedProduct;
+use App\Models\ManagementInventory;
+use App\Models\Sale;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Anula una venta siguiendo las reglas de
+ * docs/devflow/specs/2026-08-10-sale-deletion-analysis.md (R1-R8).
+ *
+ * Una venta nunca se borra físicamente: se anula (status = CANCELLED) y se
+ * revierten sus efectos. Qué se revierte depende de evidencia, no de un
+ * campo de "canal" persistido — ver §6 del análisis:
+ *   - assigned_product_movements ligados por sale_id (regalías/cambios):
+ *     siempre, es un vínculo directo sin ambigüedad de origen.
+ *   - sale_quantity de detail_assigned_products: sólo para las líneas de la
+ *     venta que NO tengan un asiento de inventario asociado (evidencia de
+ *     venta creada desde la app).
+ *   - asientos de management_inventory con reference_type=Sale::class: para
+ *     las líneas que sí lo tengan (evidencia de venta creada desde la web).
+ */
+class SaleCancellationService
+{
+    public function __construct(
+        private readonly AssignedProductMovementService $movementService,
+        private readonly ManagementInventoryService $inventoryService,
+    ) {
+    }
+
+    /**
+     * @throws SaleCancellationException Precondición no cumplida (venta
+     *         facturada, fuera de la ventana del mismo día, cuadre ya
+     *         existente, pagos ya registrados) o evidencia insuficiente
+     *         para revertir con seguridad.
+     */
+    public function cancel(Sale $sale, ?string $reason = null): Sale
+    {
+        return DB::transaction(function () use ($sale, $reason) {
+            $sale = Sale::whereKey($sale->id)->lockForUpdate()->firstOrFail();
+
+            // Idempotente: un reintento (móvil, doble clic) no debe fallar ni
+            // revertir dos veces. Debe ir DESPUÉS del lockForUpdate: dos
+            // anulaciones concurrentes de la misma venta deben serializarse
+            // aquí, no ambas leer status=CONFIRMED a la vez.
+            if ($sale->isCancelled()) {
+                return $sale;
+            }
+
+            $this->assertCanBeCancelled($sale);
+
+            $inventoryMovements = $this->fetchSaleInventoryMovements($sale);
+
+            $this->revertAssignedProductMovements($sale);
+            $this->revertAssignedProductSaleQuantity($sale, $inventoryMovements);
+            $this->revertInventoryMovements($sale, $inventoryMovements);
+            $this->cancelAccountReceivableIfCredit($sale);
+
+            $sale->update([
+                'status' => SaleStatusEnum::CANCELLED,
+                'cancelled_at' => now(),
+                'cancelled_by' => Auth::id(),
+                'cancellation_reason' => $reason,
+            ]);
+
+            return $sale->fresh();
+        });
+    }
+
+    private function assertCanBeCancelled(Sale $sale): void
+    {
+        if ($sale->isInvoiced()) {
+            throw new SaleCancellationException(
+                'Una venta facturada no se anula, se emite nota de crédito.',
+                409
+            );
+        }
+
+        $today = Carbon::today();
+        $saleDate = $sale->sale_date instanceof Carbon ? $sale->sale_date : Carbon::parse($sale->sale_date);
+        $createdAt = $sale->created_at instanceof Carbon ? $sale->created_at : Carbon::parse($sale->created_at);
+
+        // R1/R7: exige sale_date Y created_at de hoy. sale_date preserva la
+        // coherencia con el cuadre (agrupa por esa columna); created_at
+        // cierra el hueco de una venta retrofechada.
+        if (!$saleDate->isSameDay($today) || !$createdAt->isSameDay($today)) {
+            throw new SaleCancellationException(
+                'Sólo se pueden anular ventas del mismo día.',
+                422
+            );
+        }
+
+        // R2: cualquier cuadre del día bloquea, sin filtrar por estado (un
+        // cuadre "pending" ya pudo haber registrado devoluciones que
+        // dependen de sale_quantity — ver §4.4 del análisis).
+        if (DailySalesReconciliation::existsForEmployeeAndDate($sale->employee_id, $saleDate->toDateString())) {
+            throw new SaleCancellationException(
+                'El día ya tiene cuadre; no se puede anular la venta.',
+                422
+            );
+        }
+
+        // R5: cualquier pago registrado bloquea. cash_amount (abono inicial,
+        // R6) NO se considera aquí a propósito: no genera fila en payments.
+        $accountReceivable = $sale->accountReceivable;
+        if ($accountReceivable && $accountReceivable->payments()->exists()) {
+            throw new SaleCancellationException(
+                'La venta tiene pagos registrados sobre su cuenta por cobrar; no se puede anular.',
+                422
+            );
+        }
+    }
+
+    /**
+     * Regalías y cambios ligados a la venta. El vínculo es directo
+     * (assigned_product_movements.sale_id): aplica siempre, sin ambigüedad
+     * de origen, sea la venta de la app o de la web.
+     */
+    private function revertAssignedProductMovements(Sale $sale): void
+    {
+        foreach ($sale->assignedProductMovements as $movement) {
+            $this->movementService->deleteMovement($movement->id);
+        }
+    }
+
+    /**
+     * sale_quantity de las líneas que vinieron de una asignación de producto
+     * (venta creada desde la app). La asignación se resuelve por
+     * (sale.employee_id, sale.sale_date) — NUNCA por el usuario autenticado
+     * que anula: puede ser un admin sin `employee`, o distinto del vendedor
+     * que hizo la venta.
+     *
+     * Sólo procesa líneas sin evidencia de inventario: un producto con un
+     * asiento de management_inventory referenciando esta venta pertenece al
+     * flujo web, aunque el vendedor tenga una asignación ese día con el
+     * mismo producto.
+     */
+    private function revertAssignedProductSaleQuantity(Sale $sale, Collection $inventoryMovements): void
+    {
+        $inventoryHandledProductIds = $inventoryMovements
+            ->pluck('model.product_id')
+            ->filter()
+            ->unique()
+            ->all();
+
+        $linesByProduct = $sale->details
+            ->whereNotIn('product_id', $inventoryHandledProductIds)
+            ->groupBy('product_id');
+
+        if ($linesByProduct->isEmpty()) {
+            return;
+        }
+
+        $assignedProduct = AssignedProduct::where('employee_id', $sale->employee_id)
+            ->whereDate('date', $sale->sale_date)
+            ->first();
+
+        // Se resuelven todos los detalles antes de bloquear ninguno, para
+        // poder bloquearlos después en orden ascendente por id (mismo
+        // criterio que la creación) y no invertir el orden de bloqueo entre
+        // una venta concurrente y esta anulación.
+        $quantityByDetailId = [];
+
+        foreach ($linesByProduct as $productId => $lines) {
+            $detail = $assignedProduct
+                ? DetailAssignedProduct::where('assigned_products_id', $assignedProduct->id)
+                    ->where('product_id', $productId)
+                    ->first()
+                : null;
+
+            if (!$detail) {
+                // Silent skip prohibido (§4.2 del análisis): sin asignación
+                // ni evidencia de inventario no hay forma segura de saber
+                // qué se descontó. Se aborta toda la anulación.
+                $productName = $lines->first()->product_name ?? "producto #{$productId}";
+                throw new SaleCancellationException(
+                    "No se encontró evidencia (asignación de producto ni movimiento de inventario) para revertir la línea '{$productName}' de la venta #{$sale->id}.",
+                    422
+                );
+            }
+
+            $quantityByDetailId[$detail->id] = (float) $lines->sum('quantity');
+        }
+
+        ksort($quantityByDetailId);
+
+        foreach ($quantityByDetailId as $detailId => $quantity) {
+            $detail = DetailAssignedProduct::lockForUpdate()->findOrFail($detailId);
+
+            $expected = (float) $detail->sale_quantity - $quantity;
+            $newSaleQuantity = max(0, $expected);
+
+            if ($newSaleQuantity !== $expected) {
+                Log::warning('SaleCancellationService: sale_quantity hubiera quedado negativo, se recortó a 0.', [
+                    'detail_assigned_product_id' => $detail->id,
+                    'sale_id' => $sale->id,
+                ]);
+            }
+
+            $detail->update(['sale_quantity' => $newSaleQuantity]);
+
+            // Aserción defensiva del invariante (§4.4): si esto falla hay
+            // drift previo ajeno a esta venta; se aborta la transacción
+            // completa en vez de dejar un sobrante inconsistente.
+            if ((float) $detail->fresh()->stock < 0) {
+                throw new SaleCancellationException(
+                    "La reversión dejaría stock negativo en el producto asignado #{$detail->id}; anulación abortada.",
+                    500
+                );
+            }
+        }
+    }
+
+    /**
+     * Asientos de inventario que la venta generó (venta creada desde la
+     * web): compensa cada SALIDA referenciada por esta venta con un asiento
+     * DEVOLUCION (R8). Nunca borra el asiento original — el histórico de
+     * management_inventory es un libro de asientos, se compensa, no se edita.
+     */
+    private function revertInventoryMovements(Sale $sale, Collection $inventoryMovements): void
+    {
+        foreach ($inventoryMovements as $movement) {
+            $model = $movement->model;
+
+            if (!$model) {
+                throw new SaleCancellationException(
+                    "El inventario referenciado por el movimiento #{$movement->id} de la venta #{$sale->id} ya no existe; anulación abortada.",
+                    500
+                );
+            }
+
+            $this->inventoryService->registerReturn(
+                $model,
+                (float) $movement->quantity,
+                "Anulación de venta #INV-{$sale->id}",
+                $sale->id,
+                Sale::class,
+            );
+        }
+    }
+
+    /**
+     * Asientos SALIDA de management_inventory que esta venta generó. Se
+     * calcula una sola vez por anulación y se reutiliza tanto para decidir
+     * qué líneas excluir de la reversión de sale_quantity como para generar
+     * las compensaciones de inventario.
+     */
+    private function fetchSaleInventoryMovements(Sale $sale): Collection
+    {
+        return ManagementInventory::where('reference_type', Sale::class)
+            ->where('reference_id', $sale->id)
+            ->where('type', TypeInventoryManagementEnum::SALIDA->value)
+            ->with('model')
+            ->get();
+    }
+
+    /**
+     * R4: venta a crédito con cuenta por cobrar sin pagos (ya validado en
+     * assertCanBeCancelled) → se cancela la CxC. No se borra: queda como
+     * evidencia junto a la venta anulada.
+     */
+    private function cancelAccountReceivableIfCredit(Sale $sale): void
+    {
+        $sale->accountReceivable?->update([
+            'status' => AccountReceivableStatusEnum::CANCELLED,
+            'cancelled_at' => now(),
+        ]);
+    }
+}

--- a/app/Services/SaleService.php
+++ b/app/Services/SaleService.php
@@ -242,6 +242,7 @@ class SaleService
                         TypeInventoryManagementEnum::SALIDA->value,
                         'Venta de producto: ' . ($productData['name'] ?? 'Producto #' . $productData['product_id']),
                         $sale->id,
+                        Sale::class,
                     );
                 }
             }

--- a/database/migrations/2026_08_11_000001_add_reference_type_to_management_inventory_table.php
+++ b/database/migrations/2026_08_11_000001_add_reference_type_to_management_inventory_table.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\AssignedProduct;
+use App\Models\ProductReturn;
+use App\Models\Sale;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * `reference_id` no tiene tipo: la venta #5 y la devolución #5 son hoy
+     * indistinguibles entre los mismos asientos de inventario. Sin esto, la
+     * reversión de una venta anulada (creada desde la web) podría compensar
+     * el asiento equivocado. Ver docs/devflow/specs/2026-08-10-sale-deletion-analysis.md §5.2.
+     */
+    public function up(): void
+    {
+        Schema::table('management_inventory', function (Blueprint $table) {
+            $table->string('reference_type')->nullable()->after('reference_id');
+        });
+
+        // Backfill histórico: no hay ninguna otra señal fiable que la
+        // descripción del asiento para clasificar reference_id retroactivamente
+        // (reference_id nunca llevó reference_type). Los asientos "venta"
+        // legacy con reference_id NULL (datos de una versión anterior del
+        // código) quedan sin clasificar a propósito: no hay id que resolver.
+        DB::table('management_inventory')
+            ->whereNotNull('reference_id')
+            ->where(function ($query) {
+                $query->where('description', 'like', 'Asignación de producto%')
+                    ->orWhere('description', 'like', 'Ajuste de producto asignado%')
+                    ->orWhere('description', 'like', 'Eliminación de producto asignado%');
+            })
+            ->update(['reference_type' => AssignedProduct::class]);
+
+        DB::table('management_inventory')
+            ->whereNotNull('reference_id')
+            ->where(function ($query) {
+                $query->where('description', 'like', 'Devolución de producto%')
+                    ->orWhere('description', 'like', 'Reversión de devolución%');
+            })
+            ->update(['reference_type' => ProductReturn::class]);
+
+        DB::table('management_inventory')
+            ->whereNotNull('reference_id')
+            ->where('description', 'like', 'Venta de producto%')
+            ->update(['reference_type' => Sale::class]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('management_inventory', function (Blueprint $table) {
+            $table->dropColumn('reference_type');
+        });
+    }
+};

--- a/database/migrations/2026_08_11_000002_add_cancellation_and_metadata_to_sales_table.php
+++ b/database/migrations/2026_08_11_000002_add_cancellation_and_metadata_to_sales_table.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Models\AssignedProduct;
+use App\Models\Sale;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Esquema necesario para anular ventas (ver
+     * docs/devflow/specs/2026-08-10-sale-deletion-analysis.md §10):
+     * auditoría de la anulación, canal de origen (para reportería; la
+     * reversión se guía por evidencia, no por este campo) y dos columnas que
+     * el código ya envía a Sale::create() pero que Eloquent descarta en
+     * silencio por no existir (branch_id, payment_reference).
+     */
+    public function up(): void
+    {
+        Schema::table('sales', function (Blueprint $table) {
+            $table->foreignId('branch_id')->nullable()->after('employee_id')
+                ->constrained('branches')->restrictOnDelete();
+            $table->string('payment_reference')->nullable()->after('cash_amount');
+            $table->enum('channel', ['app', 'web'])->nullable()->after('client_request_uuid');
+            $table->timestamp('cancelled_at')->nullable()->after('confirmed_at');
+            $table->foreignId('cancelled_by')->nullable()->after('cancelled_at')
+                ->constrained('users');
+            $table->text('cancellation_reason')->nullable()->after('cancelled_by');
+        });
+
+        $this->backfillBranchId();
+        $this->backfillChannel();
+    }
+
+    /**
+     * branch_id se resuelve desde employees.branch_id: es la mejor
+     * aproximación disponible, aunque el empleado pudo haber cambiado de
+     * sucursal después de la venta.
+     *
+     * Se recorre por empleado (no UPDATE...JOIN) porque esa sintaxis no es
+     * portable entre MySQL y SQLite, y la suite de tests corre sobre SQLite.
+     */
+    private function backfillBranchId(): void
+    {
+        $employees = DB::table('employees')
+            ->select('id', 'branch_id')
+            ->whereNotNull('branch_id')
+            ->get();
+
+        foreach ($employees as $employee) {
+            DB::table('sales')
+                ->where('employee_id', $employee->id)
+                ->whereNull('branch_id')
+                ->update(['branch_id' => $employee->branch_id]);
+        }
+    }
+
+    /**
+     * No existe ninguna columna histórica que indique el canal. Se infiere
+     * por evidencia: si hay una AssignedProduct para (employee_id, sale_date)
+     * de la venta, se asume 'app' (el flujo de venta desde la app siempre
+     * pasa por una asignación); el resto se marca 'web'. Es una aproximación
+     * para reportería, no para la lógica de reversión (que siempre debe
+     * guiarse por evidencia directa, no por este campo).
+     */
+    private function backfillChannel(): void
+    {
+        $assignedProductDates = AssignedProduct::select('employee_id', 'date')
+            ->get()
+            ->map(fn ($row) => $row->employee_id . '|' . $row->date->toDateString())
+            ->flip();
+
+        Sale::query()->select('id', 'employee_id', 'sale_date')
+            ->chunkById(200, function ($sales) use ($assignedProductDates) {
+                foreach ($sales as $sale) {
+                    $key = $sale->employee_id . '|' . $sale->sale_date->toDateString();
+                    $channel = $assignedProductDates->has($key) ? 'app' : 'web';
+
+                    Sale::whereKey($sale->id)->update(['channel' => $channel]);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sales', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('cancelled_by');
+            $table->dropColumn(['cancelled_at', 'cancellation_reason', 'channel', 'payment_reference']);
+            $table->dropConstrainedForeignId('branch_id');
+        });
+    }
+};

--- a/database/migrations/2026_08_12_000001_restrict_delete_on_account_receivables_sales_id.php
+++ b/database/migrations/2026_08_12_000001_restrict_delete_on_account_receivables_sales_id.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Una venta nunca se borra físicamente, se anula (ver
+     * docs/devflow/specs/2026-08-10-sale-deletion-analysis.md §2 y fase 0).
+     * `SET NULL` era una trampa: si alguna vez se intentara un borrado físico
+     * (manual, un script, una regresión futura), la cuenta por cobrar
+     * sobreviviría huérfana con sus pagos, en silencio. `RESTRICT` lo
+     * convierte en un error de base de datos explícito en vez de datos
+     * inconsistentes.
+     */
+    public function up(): void
+    {
+        Schema::table('account_receivables', function (Blueprint $table) {
+            $table->dropForeign(['sales_id']);
+            $table->foreign('sales_id')->references('id')->on('sales')->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('account_receivables', function (Blueprint $table) {
+            $table->dropForeign(['sales_id']);
+            $table->foreign('sales_id')->references('id')->on('sales')->nullOnDelete();
+        });
+    }
+};

--- a/database/migrations/2026_08_12_000002_restrict_delete_on_assigned_product_movements_sale_id.php
+++ b/database/migrations/2026_08_12_000002_restrict_delete_on_assigned_product_movements_sale_id.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Mismo criterio que account_receivables.sales_id (ver la migración
+     * hermana de esta): una venta nunca se borra físicamente, se anula. Con
+     * `SET NULL`, borrar una venta dejaba la regalía/cambio sobreviviendo
+     * huérfana y su acumulador (royalties_quantity/changes_quantity) sin
+     * revertir, en silencio — exactamente el bug que motivó
+     * docs/devflow/specs/2026-08-10-sale-deletion-analysis.md. `RESTRICT`
+     * lo convierte en un error de base de datos explícito.
+     */
+    public function up(): void
+    {
+        Schema::table('assigned_product_movements', function (Blueprint $table) {
+            $table->dropForeign(['sale_id']);
+            $table->foreign('sale_id')->references('id')->on('sales')->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('assigned_product_movements', function (Blueprint $table) {
+            $table->dropForeign(['sale_id']);
+            $table->foreign('sale_id')->references('id')->on('sales')->nullOnDelete();
+        });
+    }
+};

--- a/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
+++ b/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
@@ -573,7 +573,7 @@ implementación.
 | 3 | Migraciones §10: `management_inventory.reference_type` (**bloqueante**), `sales.branch_id`, `cancelled_at`/`cancelled_by`/`cancellation_reason`, `channel`, `payment_reference` + backfill | — | ✅ hecho |
 | 4 | `SaleCancellationService`: precondiciones (§7), reversión app (§4) y web (§5), CxC a `CANCELLED` (§7.2), transacción y bloqueos (§8) | fase 3 | ✅ hecho |
 | 5 | Acción "Anular" en Filament con motivo obligatorio y aviso de devolución del abono (R6) | fase 4 | ✅ hecho |
-| 6 | `DELETE /api/sales/{id}` con pertenencia (§9), idempotencia (§8) y aviso de devolución (R6) | fase 4 | pendiente |
+| 6 | `DELETE /api/sales/{id}` con pertenencia (§9), idempotencia (§8) y aviso de devolución (R6) | fase 4 | ✅ hecho |
 | 7 | `SET NULL` → `restrictOnDelete` en `account_receivables.sales_id` y `assigned_product_movements.sale_id` (§10.6) | fase 4 | pendiente |
 
 Las fases 0, 1 y 2 eran independientes entre sí y de todo lo demás, y ya están hechas:
@@ -728,6 +728,38 @@ autorización por rol/pertenencia/permiso/estado (5), motivo obligatorio, aviso 
 notificación de error sin excepción cruda, y que la misma acción está disponible en la
 tabla. Verificado en rojo desactivando quirúrgicamente el check de pertenencia del
 cajero, el check de permiso y el `required()` del motivo, uno a la vez.
+
+La fase 6 también está hecha: `DELETE /api/sales/{id}` →
+`SaleController::cancelSale` (app móvil).
+
+- **Pertenencia (§9):** sólo si `sale.employee_id === Auth::user()->employee_id`. A
+  diferencia de Filament, aquí no hay concepto de admin/cajero — esta ruta es
+  exclusivamente del vendedor sobre sus propias ventas. 404 si la venta no existe, 403
+  si existe pero es de otro vendedor (misma distinción que
+  `AssignedProductMovementController::resolveOwnedDetail` del PR #128).
+- **Idempotencia HTTP (§8):** un segundo `DELETE` sobre una venta ya anulada responde
+  **200**, no 404/409/422 — el servicio ya es idempotente (no lanza si
+  `isCancelled()`), el controlador no necesita lógica extra: el mismo camino de éxito
+  cubre "se acaba de anular" y "ya estaba anulada". Así la cola offline del móvil no se
+  atasca con un reintento.
+- **Motivo opcional en este canal** (a diferencia de Filament, donde es obligatorio para
+  todos los roles): `nullable|string|max:500`. El vendedor suele anular al instante por
+  un error de captura; exigir motivo ahí es fricción que el análisis no pedía para esta
+  ruta específicamente.
+- **R6 en la respuesta:** si la venta es a crédito con `cash_amount > 0`, la respuesta
+  incluye `data.cash_to_return` (monto) y el mensaje de éxito indica explícitamente
+  "Recuerde devolver L X al cliente." — igual que el aviso de Filament, pero en el canal
+  que de verdad usa el vendedor al momento de anular desde el celular.
+- **Errores del servicio (`SaleCancellationException`) se mapean 1:1** al código HTTP que
+  el propio servicio ya decidió (`$e->getCode()`: 409 factura, 422 R1/R2/R5, 500
+  defensivo), con el mensaje exacto en el campo `error` de la respuesta — el móvil puede
+  mostrarlo directo, sin tener que interpretar un mensaje genérico.
+
+Cubierto por `tests/Feature/SaleCancellationApiTest.php` (10 tests): éxito con y sin
+motivo, 404, 403, idempotencia HTTP (dos `DELETE` seguidos, ambos 200), dos
+precondiciones mapeadas a 422 con el mensaje exacto del servicio, y R6 presente/ausente
+según corresponda. Verificado en rojo desactivando quirúrgicamente el check de
+pertenencia y el cálculo de `cash_to_return`.
 
 ---
 

--- a/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
+++ b/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
@@ -572,7 +572,7 @@ implementación.
 | 2 | `Sale::scopeNotCancelled` + filtrarlo en cuadre, `getSales`, ranking y reportes (§7.1). Scope equivalente para CxC canceladas (§7.2) | — | ✅ hecho |
 | 3 | Migraciones §10: `management_inventory.reference_type` (**bloqueante**), `sales.branch_id`, `cancelled_at`/`cancelled_by`/`cancellation_reason`, `channel`, `payment_reference` + backfill | — | ✅ hecho |
 | 4 | `SaleCancellationService`: precondiciones (§7), reversión app (§4) y web (§5), CxC a `CANCELLED` (§7.2), transacción y bloqueos (§8) | fase 3 | ✅ hecho |
-| 5 | Acción "Anular" en Filament con motivo obligatorio y aviso de devolución del abono (R6) | fase 4 | pendiente |
+| 5 | Acción "Anular" en Filament con motivo obligatorio y aviso de devolución del abono (R6) | fase 4 | ✅ hecho |
 | 6 | `DELETE /api/sales/{id}` con pertenencia (§9), idempotencia (§8) y aviso de devolución (R6) | fase 4 | pendiente |
 | 7 | `SET NULL` → `restrictOnDelete` en `account_receivables.sales_id` y `assigned_product_movements.sale_id` (§10.6) | fase 4 | pendiente |
 
@@ -674,6 +674,60 @@ los tests, ambos corregidos en el propio test antes de dar la fase por cerrada:
    `cancel()` vuelve a leer los mismos asientos `SALIDA` (no se marcan como compensados) y
    duplica el stock devuelto. Se agregó un test específico para ese escenario y se
    verificó en rojo: sin el guardia, el stock queda en 105 en vez de 100.
+
+La fase 5 también está hecha: acción "Anular" en `app/Filament/Resources/SaleResource.php`
+(fila de la tabla) y en `.../Pages/ViewSale.php` (cabecera de la página de detalle), con
+la lógica compartida (visibilidad, formulario, manejo de errores) centralizada en tres
+métodos estáticos de `SaleResource` para no duplicarla entre ambos lugares —
+`Filament\Tables\Actions\Action` y `Filament\Actions\Action` no comparten jerarquía, así
+que cada página construye su propia instancia pero reutiliza la misma lógica.
+
+- **Formulario:** `Textarea` de motivo, `required()` — sin él la acción falla validación
+  y no llega a invocar el servicio. Un `Placeholder` condicional muestra el aviso de R6
+  ("Esta venta a crédito tiene un abono inicial de L X...") sólo cuando
+  `payment_term = CREDIT` y `cash_amount > 0`.
+- **Errores del servicio como notificación, no como excepción cruda:** el `action()`
+  atrapa `SaleCancellationException` y muestra `Notification::make()->danger()` con el
+  mensaje exacto del servicio (p. ej. "El día ya tiene cuadre..."). La venta queda
+  intacta porque la excepción se lanzó dentro de la transacción del servicio, que hizo
+  rollback antes de propagarla.
+- **Autorización (§9), implementada en el controlador/recurso, no en el servicio** (mismo
+  patrón que `AssignedProductMovementController::resolveOwnedDetail` del PR #128):
+  - venta ya `CANCELLED` o facturada → botón oculto directamente (evita una notificación
+    de rechazo para un caso que ya se sabe inválido de antemano).
+  - permiso `Sale.delete` (reutilizado — no se creó un permiso `Sale.cancel` nuevo:
+    semánticamente reemplaza al borrado físico retirado en la fase 0, y es exactamente el
+    mismo permiso que `DeleteAction`/`DeleteBulkAction` habrían resuelto automáticamente
+    antes de quitarlos, así que la postura de seguridad no cambia).
+  - superadmin/admin: cualquier venta del día.
+  - cajero: sólo `sale.created_by === $user->id` — **no** `employee_id`.
+  - R1/R2/R5 (mismo día, sin cuadre, sin pagos) no se replican en la visibilidad del
+    botón: dependen de estado que puede cambiar entre que se renderiza la fila y se hace
+    clic, así que el servicio las valida y se comunican por notificación.
+- **Hallazgo al implementar la autorización de cajero:** `CashierSaleScope`
+  (`app/Models/Scopes/CashierSaleScope.php`) está **importada en `Sale.php` pero nunca
+  registrada** (`static::addGlobalScope(...)` no existe en el modelo) — es código muerto,
+  a pesar de que este mismo documento (§9) asumía que ya filtraba por `created_by`. El
+  filtro real hoy es `ListSales::getTableQuery`, que filtra por `employee_id` (el
+  vendedor), no por `created_by` (quien creó el registro) — dos criterios distintos para
+  lo que debería ser el mismo control. La autorización de la acción "Anular" se
+  implementó correctamente usando `created_by` (el criterio que dicta este documento),
+  **independiente** de ese scope muerto — no se tocó `CashierSaleScope` ni
+  `ListSales::getTableQuery`, por ser una inconsistencia preexistente y más amplia que el
+  alcance de esta fase. Queda pendiente como deuda técnica a resolver aparte.
+- **UI de auditoría:** `ViewSale` gana una sección "Anulación" (`cancelledBy`,
+  `cancelled_at`, `cancellation_reason`), visible sólo si `isCancelled()`. La sección
+  "Información Adicional" ya mostraba `payment_reference` — ahora se popula de verdad
+  gracias al fix de esquema de la fase 3 (antes se descartaba en silencio).
+- La acción, tras ejecutarse desde `ViewSale`, redirige a la misma URL de vista: el
+  infolist lee del `$record` cargado al montar la página, que no se refresca solo tras la
+  acción (a diferencia de la tabla de Filament, que sí se re-renderiza automáticamente).
+
+Cubierto por `tests/Feature/SaleCancellationFilamentActionTest.php` (10 tests):
+autorización por rol/pertenencia/permiso/estado (5), motivo obligatorio, aviso de R6,
+notificación de error sin excepción cruda, y que la misma acción está disponible en la
+tabla. Verificado en rojo desactivando quirúrgicamente el check de pertenencia del
+cajero, el check de permiso y el `required()` del motivo, uno a la vez.
 
 ---
 

--- a/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
+++ b/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
@@ -1,0 +1,640 @@
+# Análisis: borrado / anulación de ventas
+
+**Fecha:** 2026-08-10
+**Estado:** análisis cerrado — reglas de negocio definidas (§0), sin decisiones pendientes (§11). Listo para implementar (§12).
+**Relacionado:** `docs/devflow/bug-fixes/2026-08-10-assigned-product-movements-known-issues.md` (Pendiente B)
+
+---
+
+## 0. Reglas de negocio definidas
+
+Decisiones tomadas el 2026-08-10. Todo el resto del documento está condicionado a ellas.
+
+| # | Regla |
+|---|---|
+| R1 | **Ventana temporal:** sólo se puede anular una venta **el mismo día**. Otro día, no se permite. |
+| R2 | **Cuadre:** si el día ya tiene cuadre, no se permite anular. |
+| R3 | **Contado:** se puede anular aunque la venta esté `paid`. |
+| R4 | **Crédito:** sólo si la cuenta por cobrar **no tiene ningún pago registrado**. En ese caso se anula la venta y la CxC se marca como **`CANCELLED`** (no se borra). |
+| R5 | **Con pagos registrados:** prohibido anular, sin excepción. |
+| R6 | **Abono inicial:** una venta a crédito con `cash_amount > 0` **sí se puede anular** (ese monto se descuenta directo, no genera fila en `payments`). La UI debe avisar cuánto hay que devolverle al cliente. |
+| R7 | **"Mismo día" = `sale_date` y `created_at`**, ambos hoy. Además, **se bloquea la edición de la fecha de venta en la web**: el campo pasa a sólo lectura y la fecha la fija el servidor. |
+| R8 | **Reversión de inventario (web):** asiento compensatorio de tipo **`DEVOLUCION`**. |
+
+### Lo que estas reglas eliminan del problema
+
+R1 + R2 juntas son una simplificación grande, y conviene dejarla explícita porque
+condiciona toda la arquitectura:
+
+- **No hay que recalcular ni reabrir cuadres.** El cuadre siempre se calcula *después* de
+  cualquier anulación posible, así que basta con excluir las ventas anuladas de las
+  consultas (§7.1). Los snapshots de `daily_sales_reconciliations` nunca quedan mintiendo.
+- **No hay que revertir efectivo ya contado.** Ninguna anulación puede tocar un día cerrado.
+- **No hay que tocar `returned_quantity`.** Las devoluciones del sobrante sólo se registran
+  desde el flujo de cuadre, y ese flujo crea una fila `pending` en
+  `daily_sales_reconciliations` en cuanto se inicializa
+  (`CreateReconciliation::createPendingReconciliation`). Como R2 bloquea ante *cualquier*
+  cuadre —incluido el pendiente—, el invariante que preocupaba en §4.4 no puede romperse.
+- **No hay reapertura de cuadre que diseñar** (§11.5 del análisis original queda cerrada).
+
+### Estados anulables (resuelve el problema de `canBeCancelled()`)
+
+`SaleStatusEnum::canBeCancelled()` hoy admite sólo `DRAFT` y `CONFIRMED`, y bloquearía el
+89% de las ventas reales. Con R3 y R4 queda así:
+
+| Estado | ¿Anulable? |
+|---|---|
+| `DRAFT` | sí (no se usa hoy) |
+| `CONFIRMED` | sí |
+| `PARTIALLY_PAID` | sí, sujeto a R4/R5 |
+| `PAID` | **sí** (era el caso bloqueado) |
+| `CANCELLED` | no-op idempotente, responde éxito |
+| facturada (`invoice_number` no nulo) | no, nunca |
+
+Hay que reescribir `canBeCancelled()` en consecuencia, o —mejor— **no usarlo** para esta
+decisión y dejar toda la política en el servicio de anulación, donde se puede combinar con
+la fecha, el cuadre y los pagos. El método del enum sólo conoce el estado, y la política
+real depende de cuatro cosas más.
+
+---
+
+## 1. Punto de partida: el borrado ya existe y está roto
+
+Antes de diseñar nada, esto es lo que hay hoy en producción:
+
+| Dónde | Qué hace |
+|---|---|
+| `app/Filament/Resources/SaleResource.php:124` | `DeleteBulkAction` en la tabla de ventas |
+| `app/Filament/Resources/SaleResource/Pages/EditSale.php:17` | `DeleteAction` en el encabezado de edición |
+| API (`routes/api.php`) | **no existe** endpoint de borrado |
+
+Ambas acciones de Filament hacen un `delete()` de Eloquent sin ninguna reversión.
+Comprobado contra la BD real (dentro de una transacción revertida):
+
+```
+Probando borrar venta #458 (3 detalles)
+FALLÓ: SQLSTATE[23000]: 1451 Cannot delete or update a parent row:
+       a foreign key constraint fails (`jaco`.`sale_details`, ...)
+```
+
+**No corrompe datos, pero porque la base lo impide, no porque el código lo prevea.**
+Las FKs reales hacia `sales` son:
+
+| Tabla | Columna | ON DELETE | Consecuencia |
+|---|---|---|---|
+| `sale_details` | `sale_id` | **NO ACTION** (=RESTRICT) | el borrado falla siempre que la venta tenga líneas |
+| `sale_tax_totals` | `sale_id` | CASCADE | se borra en silencio (hoy la tabla está vacía: 0 filas) |
+| `account_receivables` | `sales_id` | **SET NULL** | la cuenta por cobrar sobrevive huérfana, con sus pagos |
+| `assigned_product_movements` | `sale_id` | **SET NULL** | la regalía sobrevive y el acumulador no se revierte |
+
+Es decir: si alguien "arregla" el `RESTRICT` de `sale_details` sin más, el borrado
+empieza a funcionar y **destruye silenciosamente** cuentas por cobrar y regalías.
+Ese es el riesgo principal de este trabajo.
+
+Dos datos más que condicionan el diseño:
+
+- **`invoice_number` nunca se asigna** en ningún punto del código. Hoy ninguna venta
+  está facturada, así que no hay problema fiscal de numeración — pero el campo existe
+  y el diseño debe contemplarlo.
+- **`sale_tax_totals` nunca se escribe** (0 filas). Su CASCADE es inofensivo hoy.
+
+---
+
+## 2. Decisión de fondo: anulación, no borrado físico
+
+**Recomendación: implementar anulación (`status = CANCELLED` + reversión de efectos)
+y prohibir el borrado físico**, incluso desde Filament.
+
+Razones, de más a menos fuerte:
+
+1. **La idempotencia depende de que la fila exista.** `sales.client_request_uuid` tiene
+   índice único y `SaleController::createSale` responde "ya registrada" cuando lo
+   encuentra. Si se borra la fila, el uuid queda libre: un reintento tardío del móvil
+   (o un reenvío de la cola offline) **vuelve a crear la venta que se acababa de borrar**,
+   y con ella vuelve a descontar `sale_quantity`. La anulación conserva la fila y el
+   reintento sigue respondiendo "ya registrada".
+2. **La anulación es idempotente por construcción.** Anular dos veces es un no-op
+   (`if ($sale->isCancelled()) return;`). Borrar dos veces, con reversión de por medio,
+   revierte dos veces si no se acierta con el bloqueo.
+3. **Auditoría.** Es una operación de dinero: hay que poder responder quién anuló qué y
+   cuándo. `sales` ya tiene `updated_by`; falta `cancelled_at` / `cancelled_by` / `cancellation_reason`.
+4. **El patrón ya existe en el código.** `ProductReturnService::reverseInventoryMovement`
+   (`app/Services/ProductReturnService.php:86`) revierte **creando un movimiento
+   compensatorio**, no borrando el original. El histórico de `management_inventory` es
+   un libro de asientos: se compensa, no se edita.
+5. `SaleStatusEnum::CANCELLED` y `Sale::canBeCancelled()` ya existen, sin usarse.
+
+**Consecuencia de diseño:** todo lo que sigue describe "anular". Si el negocio insiste
+en borrado físico para algún caso (p. ej. una venta creada por error hace 5 minutos),
+que sea un caso aparte, restringido y posterior — y siempre ejecutando primero la misma
+reversión.
+
+Ver §0 para los estados anulables ya definidos.
+
+---
+
+## 3. Inventario completo de efectos de una venta
+
+Todo lo que una venta toca al crearse, y qué hay que hacer al anularla:
+
+| # | Efecto | App | Web | Reversión |
+|---|---|---|---|---|
+| 1 | `sale_details` (líneas) | ✅ | ✅ | conservar (el histórico es la evidencia) |
+| 2 | `detail_assigned_products.sale_quantity` | ✅ | ❌ | restar la cantidad vendida |
+| 3 | `detail_assigned_products.royalties_quantity` / `changes_quantity` | ✅ | ❌ | revertir vía `AssignedProductMovementService::deleteMovement` |
+| 4 | `assigned_product_movements` (filas con `sale_id`) | ✅ | ❌ | eliminar junto con su acumulador |
+| 5 | `finished_product_inventories.stock` | ❌ | ✅ | movimiento compensatorio de entrada |
+| 6 | `management_inventory` (asiento `salida`) | ❌ | ✅ | **no borrar**: crear el asiento inverso |
+| 7 | `account_receivables` (+ `remaining_balance`, `status`) | ✅ | ✅ | R4: `status = CANCELLED` + `cancelled_at` (sólo si no tiene pagos) |
+| 8 | `payments` sobre esa CxC | ✅ | ✅ | R5: si existe alguno, la anulación se rechaza |
+| 9 | `client_visits` (visita del día) | ✅ | ❌ | no revertir (§5.5) |
+| 10 | `daily_sales_reconciliations` (snapshot del cuadre) | ✅ | ✅ | R2: bloquear — nunca se recalcula (§7.1) |
+| 11 | `sale_tax_totals` | ❌ | ❌ | no aplica (nunca se escribe) |
+
+Nota sobre el punto 9: la web (`app/Livewire/Sales/CreateSale.php:443`) **no** registra
+visita de cliente; la app sí (`SaleService::createSale`, paso 7). Es una asimetría
+existente entre los dos flujos, no introducida por este trabajo.
+
+---
+
+## 4. Caso A — venta creada desde la app
+
+Tu descripción es correcta: **no toca inventario**, porque el inventario ya se descontó
+al asignarle el producto al vendedor. Lo que hay que revertir es el detalle del producto
+asignado. Pero hay cinco trampas concretas.
+
+### 4.1 La asignación se debe resolver por la venta, no por el usuario logueado
+
+> R1 obliga a que la anulación sea del mismo día, así que la parte de la fecha parece
+> irrelevante. **No lo es:** quien anula puede ser un admin o un cajero, que no tienen
+> `employee` asociado. El problema sigue en pie por el actor, no por la fecha.
+
+La creación busca la asignación así (`app/Services/SaleService.php`, rama `origin === 'api'`):
+
+```php
+AssignedProduct::where('employee_id', Auth::user()->employee->id)
+    ->todayAssignments()   // whereDate('date', today())
+    ->first();
+```
+
+Usa **el empleado del usuario autenticado** y **la fecha de hoy**. Para revertir eso no
+sirve: quien anula puede ser un admin (que no tiene `employee`), o la anulación puede
+ocurrir al día siguiente. La reversión debe resolver:
+
+```php
+AssignedProduct::where('employee_id', $sale->employee_id)
+    ->whereDate('date', $sale->sale_date)
+    ->first();
+```
+
+Si se copia el patrón de la creación, la anulación de un admin fallaría con
+`Attempt to read property "id" on null`, o peor, revertiría contra la asignación
+equivocada. Ojo también con la duplicidad: `createMovementFromSaleProduct` ya usa
+`$sale->employee_id + whereDate($sale->sale_date)` mientras la rama de venta usa
+`Auth + today()`. **Los dos caminos de la misma función miran asignaciones distintas.**
+
+### 4.2 El "silent skip" de la creación se hereda en la reversión
+
+La creación hace `if ($detail) { ... }` — si no encuentra el detalle, **no descuenta y no
+avisa**. Al revertir hay que decidir explícitamente qué pasa cuando el detalle ya no
+existe (asignación borrada, producto quitado de la asignación):
+
+- **Recomendado: fallar la anulación completa** con un mensaje claro. Un descuadre
+  silencioso es exactamente el bug que acabamos de corregir.
+- Alternativa: revertir lo que se pueda y devolver la lista de líneas no revertidas para
+  que un humano decida. Nunca continuar en silencio.
+
+### 4.3 Revertir por `quantity`, no por `base_quantity`
+
+La creación incrementa `sale_quantity` con `$productData['quantity']`; el inventario web,
+en cambio, usa `base_quantity`. En la app hoy ambos valen lo mismo
+(`prepareSaleDetailsData` hace `'quantity' => (int)…, 'base_quantity' => (int)…`), pero
+si algún día se activa `conversion_factor` dejan de coincidir. La reversión debe usar
+**la misma magnitud que usó la creación** (`sale_details.quantity`), y conviene dejarlo
+comentado en el código para que no se "corrija" a `base_quantity` por error.
+
+### 4.4 El invariante frente a las devoluciones — cubierto por R2
+
+`CreateReconciliation::updateReturnedQuantity` escribe `returned_quantity` con tope
+`quantity - sale_quantity`. Si después bajara `sale_quantity`, el sobrante calculado
+subiría por encima del físico.
+
+**R2 lo previene por completo:** ese flujo llama antes a `createPendingReconciliation()`,
+que inserta la fila de cuadre en estado `pending`. Como el bloqueo de R2 consulta
+`exists()` sin filtrar por estado —igual que el guardia de creación ya existente en
+`SaleController::validateExistingReconciliation`—, en cuanto hay una devolución registrada
+ya no se puede anular.
+
+→ Requisito derivado: **el bloqueo por cuadre debe mirar cualquier estado**, no sólo
+`completed`. Si alguien "optimiza" ese chequeo filtrando por cuadres completados, reabre
+este agujero. Vale la pena un test explícito con cuadre `pending`.
+
+→ Aun así, conviene dejar una **aserción defensiva** del invariante
+`sale_quantity + returned_quantity + changes + royalties ≤ quantity` al final de la
+reversión: si alguna vez falla, indica que R2 se saltó por otra vía.
+
+### 4.5 Bloqueo y orden
+
+- `lockForUpdate()` sobre cada `detail_assigned_products` afectado, igual que en la venta
+  y en los movimientos (ya corregido en el PR #128).
+- Revertir **primero los movimientos** (regalías/cambios) y **después `sale_quantity`**, o
+  al revés — pero de forma fija, no dependiente del orden de las líneas. Mismo criterio que
+  se aplicó en `createSaleDetails`.
+- Piso en 0 con detección: si al restar quedaría negativo, hay drift previo. Recortar a 0
+  **y registrar un warning** en vez de tragárselo.
+- Los movimientos ya tienen la reversión resuelta:
+  `AssignedProductMovementService::deleteMovement` revierte el acumulador con bloqueo y
+  piso en 0. Basta con iterar `$sale->assignedProductMovements` — la relación ya existe en
+  `Sale` (`app/Models/Sale.php`).
+
+---
+
+## 5. Caso B — venta creada desde la web
+
+También correcto tu planteamiento: aquí **sí** hay que tocar inventario y **no** hay
+asignación que revertir, porque el cajero/admin no tiene productos asignados. Pero esta
+rama tiene un problema de datos que hoy hace la reversión **imposible de hacer bien**.
+
+### 5.1 No se puede saber de qué inventario salió el producto
+
+La creación web (`app/Livewire/Sales/CreateSale.php:516`) resuelve el inventario con
+`FinishedProductInventory::find($item['inventory_id'])`, donde `inventory_id` vive sólo en
+el estado del componente Livewire. **`sale_details` no tiene columna `inventory_id`**, y —
+esto es lo grave — **`sales` no tiene columna `branch_id`**:
+
+```
+DESCRIBE sales →  id, invoice_number, invoice_series_id, client_id, employee_id,
+                  sale_date, due_date, status, payment_term, payment_method,
+                  cash_amount, subtotal, discount_*, total_amount, notes,
+                  client_request_uuid, created_by, updated_by, confirmed_at, timestamps
+```
+
+`SaleService::createSale` pasa `'branch_id' => $saleData['branch_id']` a `Sale::create()`,
+pero `branch_id` **no está en `$fillable` ni existe como columna**: Eloquent lo descarta en
+silencio. Lo mismo ocurre con `payment_reference` (se envía desde la API y desde la web,
+no está en `$fillable` ni en la tabla) y con `deposit_id` (está en `$fillable` pero no en
+la tabla).
+
+→ Sin sucursal en la venta, restaurar stock exige adivinar el inventario por
+`(product_id, branch)` usando `employee->branch_id` **actual**, que puede haber cambiado.
+Es una fuente de errores garantizada.
+
+### 5.2 La fuente de verdad correcta son los asientos de `management_inventory`
+
+En vez de re-resolver el inventario, la reversión debe leer los asientos que la propia
+venta generó y compensarlos uno a uno. Es el patrón de `ProductReturnService` y es exacto:
+compensa contra el mismo `model_id`, con la misma cantidad, aunque la sucursal del empleado
+haya cambiado después.
+
+**Pero hay una colisión que hay que resolver antes:** `management_inventory` guarda
+`reference_id` sin un `reference_type`. `SaleService` escribe `reference_id = $sale->id` y
+`ProductReturnService` escribe `reference_id = $productReturn->id`, ambos sobre
+`model_type = FinishedProductInventory`. La venta #5 y la devolución #5 son
+indistinguibles. Hay 1.396 asientos de tipo `salida` en la BD.
+
+→ **Prerrequisito bloqueante:** añadir `reference_type` (morph) a `management_inventory`,
+o una columna `sale_id` dedicada. Sin eso, cualquier reversión "por evidencia" puede
+compensar el asiento equivocado.
+
+### 5.3 Qué tipo de movimiento usar para compensar
+
+`ManagementInventoryService` tiene dos tipos que suben stock: `ENTRADA` y `DEVOLUCION`
+(`registerEntry` / `registerReturn`, ambos `increment('stock')`).
+
+**Decidido (R8): `DEVOLUCION`.** Es el correcto semánticamente para una venta anulada y
+deja el reporte de inventario legible frente a las entradas por producción o compra.
+
+La descripción del asiento debe permitir rastrear el par: p. ej.
+`"Anulación de venta #INV-458 - {producto}"`, siguiendo el formato que ya usa
+`ProductReturnService`: `"Reversión de devolución #{id} - ..."`.
+
+### 5.4 Anular no puede fallar por falta de stock
+
+`registerReturn` sólo incrementa, así que no falla. Pero **no hay que caer en la tentación
+de usar `registerExit` inverso ni de validar stock**: la anulación devuelve producto, nunca
+lo retira. Si en el futuro se implementa "editar venta", ahí sí habrá que validar.
+
+### 5.5 La visita del cliente no se revierte
+
+La web ni siquiera la registra. En la app, la visita es un hecho ocurrido (el vendedor
+estuvo allí) independiente de que la venta se anule. Recomendación: **no tocar
+`client_visits`**, y dejarlo escrito para que no se reabra la discusión.
+
+---
+
+## 6. Cómo distinguir el origen de la venta (problema real)
+
+No hay forma fiable hoy. `sales` no tiene columna de canal, y el `'origin' => 'api'` que
+usa `SaleService` vive sólo en el array de entrada, nunca se persiste.
+
+La heurística obvia — "tiene `client_request_uuid` ⇒ vino de la app" — **no funciona**:
+
+```
+ventas con client_request_uuid: 0
+ventas sin client_request_uuid: 426
+```
+
+La columna se añadió el 2026-06-13 y no hay datos históricos. Además `SaleRequest` la
+declara `nullable`, así que una app vieja puede seguir sin enviarla.
+
+**Recomendación doble:**
+
+1. **Añadir `sales.channel`** (`enum('app','web')`, no nulo, con default por migración) y
+   backfill del histórico por la evidencia disponible: existe una `AssignedProduct` para
+   `(employee_id, sale_date)` y hay `detail_assigned_products` de esos productos ⇒ `app`;
+   hay asientos de `management_inventory` con ese `sale_id` ⇒ `web`. Revisar a mano lo
+   ambiguo (deberían ser pocas).
+2. **Pero no basar la reversión en el canal, sino en la evidencia.** El servicio de
+   anulación debería preguntarse, para cada venta:
+   - ¿hay `detail_assigned_products` para `(sale.employee_id, sale.sale_date, product_id)`?
+     → revertir `sale_quantity`.
+   - ¿hay asientos de `management_inventory` con esta venta como referencia?
+     → compensarlos.
+
+   Así una venta mal clasificada, o un caso mixto futuro, se revierte igual de bien.
+   El `channel` queda para reportería, permisos y mensajes de UI.
+
+---
+
+## 7. Precondiciones que deben bloquear la anulación
+
+Cada una debe ser un chequeo explícito con mensaje propio, no un `try/catch` genérico.
+El orden importa: primero el no-op idempotente, después las baratas, al final las que
+consultan otras tablas.
+
+```
+0. venta ya CANCELLED            → éxito (no-op, §8)
+1. venta facturada                → 409 "Una venta facturada no se anula, se emite nota de crédito"
+2. R1: no es del día              → 422 "Sólo se pueden anular ventas del mismo día"
+3. R2: existe cuadre (cualquier estado) → 422 "El día ya tiene cuadre"
+4. R5: la CxC tiene pagos         → 422 "La venta tiene pagos registrados"
+5. autorización por rol/canal     → 403
+```
+
+### 7.0 R1 / R7 — sólo el mismo día
+
+**El chequeo exige las dos fechas: `sale_date` = hoy **y** `created_at` = hoy.** La primera
+preserva la coherencia con el cuadre (que agrupa por `sale_date`); la segunda cierra el
+hueco de la retrofecha.
+
+**Además se bloquea la edición de la fecha de venta en la web.** Hoy es un campo libre:
+
+- `resources/views/livewire/sales/create-sale.blade.php:102` →
+  `<input type="date" wire:model="sale_date" …>`
+- `app/Livewire/Sales/CreateSale.php:34,78,479` → la propiedad se inicializa con
+  `now()` pero el usuario puede sobrescribirla, y se guarda tal cual.
+
+Cambio requerido: el input pasa a **sólo lectura** (mostrar la fecha, no permitir editarla)
+y el `save()` debe fijar `'sale_date' => now()` en el servidor, **sin confiar en la
+propiedad del componente** — un campo `readonly` en el HTML no impide que un cliente
+Livewire manipulado envíe otra fecha. Las dos cosas, no una.
+
+Con esto, `sale_date` y `created_at` coinciden siempre para ventas nuevas y la doble
+verificación se vuelve redundante en la práctica — pero se deja igual, porque protege al
+histórico ya existente (426 ventas creadas bajo las reglas viejas).
+
+**Zona horaria:** `config/app.php` usa `America/Tegucigalpa`. "Hoy" es el día local y el
+corte es la medianoche local. Una venta de las 23:55 tiene cinco minutos de ventana. Es
+consecuencia directa de R1, no un defecto — pero el mensaje de error debe decir "sólo el
+mismo día" para que el vendedor no lo lea como un bug.
+
+### 7.1 R2 — cuadre del día
+
+`daily_sales_reconciliations` guarda **snapshots calculados**, no vistas en vivo:
+`total_cash_sales`, `cash_sales`, `total_credit_sales`, `deposit_sales`, `total_sales`,
+`total_cash_expected`, `cash_difference`, … Si se anula una venta de un día ya cuadrado,
+el snapshot queda mintiendo y el `cash_difference` calculado ese día deja de tener sentido.
+
+Ya existe el guardia simétrico para creación:
+`SaleController::validateExistingReconciliation` (`app/Http/Controllers/SaleController.php:41`)
+impide crear ventas si ya hay cuadre del día. **La anulación necesita el mismo bloqueo**
+(hay 6 cuadres en la BD).
+
+**R2 resuelve esto bloqueando**, y con eso los snapshots nunca quedan desactualizados: no
+hay que recalcular ni reabrir nada. El chequeo debe consultar `exists()` **sin filtrar por
+estado** (ver §4.4: un cuadre `pending` también bloquea).
+
+**Consecuencia obligatoria:** `CreateReconciliation` carga las ventas del día **sin filtrar
+por estado** (`app/Livewire/Reconciliations/CreateReconciliation.php:208`). Como sí se
+pueden anular ventas del día antes del cuadre, **hay que añadir el filtro
+`status != cancelled`** o la venta anulada seguirá sumando. Rastrear el cambio en:
+
+| Dónde | Qué suma |
+|---|---|
+| `CreateReconciliation:208` | ventas del día del empleado (alimenta todos los totales del cuadre) |
+| `SaleController::getSales` | listado del día en la app |
+| `SalesRankingWidget` | ranking de ventas |
+| Dashboards / reportes que agreguen `sales` | revisar uno por uno |
+
+Conviene resolverlo con un **scope reutilizable** (`Sale::scopeNotCancelled`) en vez de
+repetir el `where` en cada consulta, y añadirlo a la lista de revisión de cualquier reporte
+nuevo.
+
+### 7.2 R4/R5 — cuenta por cobrar y pagos
+
+Regla: **la venta a crédito sólo se anula si su CxC no tiene ningún pago registrado**. Con
+cualquier pago aplicado, prohibido (R5).
+
+Hoy hay 21 CxC ligadas a ventas y 8 pagos registrados.
+
+**Chequeo:** `$sale->accountReceivable?->payments()->exists()` → si existe alguno, 422.
+
+**Acción (R4): marcar la CxC como cancelada, no borrarla.** No hace falta ninguna
+migración: `account_receivables.status` ya es
+`enum('pending','paid','overdue','cancelled')` y la columna `cancelled_at` ya existe (ambas
+verificadas contra la BD).
+
+```php
+$sale->accountReceivable?->update([
+    'status'       => AccountReceivableStatusEnum::CANCELLED,
+    'cancelled_at' => now(),
+]);
+```
+
+Consecuencia a revisar: **toda consulta de CxC debe excluir las canceladas.** El estado
+existía en el enum pero nunca se usaba, así que es probable que ninguna consulta filtre por
+él. Hay que rastrearlo en `AccountReceivableController::getAccountReceivable`,
+`getPaymentsToDay`, `AccountReceivableResource` (Filament) y en la validación
+`AccountReceivableService::validateSale`, que cuenta las cuentas activas del cliente. Mismo
+criterio que el `scopeNotCancelled` de ventas: un scope reutilizable, no `where` sueltos.
+
+Ojo con el orden dentro de la transacción: cancelar la CxC **antes** de tocar la venta, para
+que el `SET NULL` de `account_receivables.sales_id` no llegue a intervenir en ningún caso.
+
+### 7.2.1 R6 — abono inicial
+
+Una venta a crédito puede llevar `cash_amount > 0` (el cliente abona algo al momento). Ese
+abono **no genera fila en `payments`**: `AccountReceivableService::create` lo descuenta
+antes, creando la CxC ya con `total_amount = total − abono`.
+
+**Decisión (R6): se permite anular.** R1+R2 garantizan que el cuadre aún no se hizo, así que
+el efectivo se autocorrige solo al excluir la venta anulada de los totales.
+
+Requisito de UI, no opcional: antes de confirmar, mostrar **"Debe devolver L X al cliente"**
+con `X = sale.cash_amount`. Aplica en la app y en Filament. Sin ese aviso, el vendedor
+anula y se queda con dinero que ya no corresponde a ninguna venta.
+
+Importante para quien implemente: el chequeo de R5 es **`payments()->exists()`, y `cash_amount`
+NO se toma en cuenta**. Queda escrito aquí para que no se "corrija" a futuro pensando que es
+un descuido.
+
+### 7.3 Venta facturada
+
+`isInvoiced()` ya existe. Hoy siempre es falso (`invoice_number` no se asigna en ninguna
+parte del código), pero el guardia debe estar desde el día 1: una factura emitida no se
+anula, se emite nota de crédito.
+
+### 7.4 Rol y pertenencia
+
+Ver §9. R1 ya acota la ventana temporal para todos los roles por igual.
+
+---
+
+## 8. Concurrencia, idempotencia y transaccionalidad
+
+- **Una sola transacción** para toda la anulación: estado + acumuladores + movimientos +
+  asientos de inventario + CxC. `ManagementInventoryService` abre su propia
+  `DB::transaction` por movimiento; anidadas en Laravel funcionan como savepoints, así que
+  la externa sigue mandando. Verificarlo con un test que fuerce fallo a mitad.
+- **`lockForUpdate`** sobre la venta y sobre cada `detail_assigned_products`, en orden
+  estable por `id` para no invertir el orden de bloqueo respecto a la creación (riesgo de
+  deadlock si un vendedor anula mientras otro vende el mismo producto).
+- **Idempotencia:** `if ($sale->isCancelled()) return;` **dentro** de la transacción y
+  después del `lockForUpdate`, no antes. Dos DELETE simultáneos del móvil deben revertir
+  una sola vez.
+- **Reintento del móvil:** el endpoint de anulación debe responder 200 (no 404/409) si la
+  venta ya está anulada, para que la cola offline no se atasque.
+
+---
+
+## 9. Autorización
+
+R1 (mismo día) y R2 (sin cuadre) aplican **a todos los roles por igual**, incluido el admin.
+Encima de eso:
+
+| Actor | Puede anular | Restricciones adicionales |
+|---|---|---|
+| Vendedor (app) | sus propias ventas | mismo `employee_id` que la venta |
+| Cajero (web) | las que él creó | `CashierSaleScope` ya filtra por `created_by`; respetarlo también en la anulación |
+| Admin / superadmin | todas las del día | motivo obligatorio, queda auditado |
+
+Nota: `ListSales::getTableQuery` filtra por `employee_id` para el cajero, mientras
+`CashierSaleScope` filtra por `created_by`. **Son dos criterios distintos para el mismo
+rol**; conviene unificarlos antes de colgar permisos de anulación encima.
+
+---
+
+## 10. Deuda de esquema previa (prerrequisitos)
+
+Ordenados por bloqueo:
+
+1. **`management_inventory.reference_type`** (o `sale_id` dedicado) — sin esto la reversión
+   web no es fiable. **Bloqueante.**
+2. **`sales.branch_id`** — hoy se envía y se descarta en silencio; necesario para reportería
+   y como respaldo de la resolución de inventario. Backfill desde `employee.branch_id`.
+3. **`sales.cancelled_at`, `cancelled_by`, `cancellation_reason`** — auditoría.
+4. **`sales.channel`** (`app`/`web`) — §6.
+5. **`sales.payment_reference`** — se envía desde la API y desde la web y se pierde; sin él
+   no se puede rastrear una transferencia de una venta anulada. (`deposit_id` está en
+   `$fillable` pero tampoco existe como columna: decidir si se agrega o se quita del modelo.)
+6. Revisar el `SET NULL` de `account_receivables.sales_id` y de
+   `assigned_product_movements.sale_id`: una vez que exista reversión explícita, el
+   `SET NULL` es una trampa que deja datos inconsistentes en silencio. Cambiar a
+   `restrictOnDelete` refuerza "no se borra, se anula".
+
+---
+
+## 11. Decisiones — todas cerradas
+
+No queda ninguna decisión de negocio pendiente. El análisis está listo para pasar a
+implementación.
+
+| Pregunta | Resolución |
+|---|---|
+| ¿Qué estados se pueden anular? | §0 — incluye `PAID` de contado |
+| ¿Qué pasa con los pagos ya recibidos? | R5 — prohibido anular |
+| ¿Anular días anteriores / reabrir cuadres? | R1/R2 — no. **No se diseña reapertura de cuadre** |
+| ¿Venta a crédito con abono inicial? | R6 — se permite, con aviso de devolución en la UI |
+| ¿"Mismo día" por qué campo? | R7 — `sale_date` **y** `created_at`, y se bloquea editar la fecha en la web |
+| ¿`DEVOLUCION` o `ENTRADA`? | R8 — `DEVOLUCION` |
+| ¿Se borra o se cancela la CxC? | R4 — `status = CANCELLED` + `cancelled_at` |
+| ¿Anulación parcial (quitar una línea)? | Fuera de alcance — es otro ciclo (recalcular totales, CxC e impuestos) |
+| ¿Sigue existiendo el borrado físico? | No — se retiran `DeleteAction` y `DeleteBulkAction` de Filament y se sustituyen por "Anular" |
+
+---
+
+## 12. Plan de implementación sugerido
+
+| Fase | Contenido | Depende de | Estado |
+|---|---|---|---|
+| 0 | Retirar `DeleteAction`/`DeleteBulkAction` de Filament (hoy sólo producen un error SQL) | — | ✅ hecho (rama `feature/sale-cancellation`) |
+| 1 | **R7 web:** fecha de venta a sólo lectura en el blade + `sale_date = now()` forzado en el servidor (§7.0) | — | ✅ hecho |
+| 2 | `Sale::scopeNotCancelled` + filtrarlo en cuadre, `getSales`, ranking y reportes (§7.1). Scope equivalente para CxC canceladas (§7.2) | — | ✅ hecho |
+| 3 | Migraciones §10: `management_inventory.reference_type` (**bloqueante**), `sales.branch_id`, `cancelled_at`/`cancelled_by`/`cancellation_reason`, `channel`, `payment_reference` + backfill | — | pendiente |
+| 4 | `SaleCancellationService`: precondiciones (§7), reversión app (§4) y web (§5), CxC a `CANCELLED` (§7.2), transacción y bloqueos (§8) | fase 3 | pendiente |
+| 5 | Acción "Anular" en Filament con motivo obligatorio y aviso de devolución del abono (R6) | fase 4 | pendiente |
+| 6 | `DELETE /api/sales/{id}` con pertenencia (§9), idempotencia (§8) y aviso de devolución (R6) | fase 4 | pendiente |
+| 7 | `SET NULL` → `restrictOnDelete` en `account_receivables.sales_id` y `assigned_product_movements.sale_id` (§10.6) | fase 4 | pendiente |
+
+Las fases 0, 1 y 2 eran independientes entre sí y de todo lo demás, y ya están hechas:
+
+- La 0 quitó dos botones que sólo producían un error SQL
+  (`app/Filament/Resources/SaleResource.php`, `.../Pages/EditSale.php`).
+- La 1 cierra el hueco de la retrofecha: el input de fecha quedó `readonly`/`disabled`
+  en `create-sale.blade.php` y `CreateSale::save()` ya no confía en la propiedad del
+  componente, persiste `now()` en el servidor sin importar lo que llegue del cliente.
+- La 2 añadió `Sale::scopeNotCancelled` y `AccountReceivable::scopeNotCancelled`, y se
+  aplicaron en: `SaleController::getSales`, `CreateReconciliation::loadEmployeeDataOnly`,
+  `SalesRankingWidget`, `StatsOverview` (ventas del mes + empleado destacado),
+  `AccountReceivableController::getAccountReceivable` y `getPaymentsToDay`.
+  `AccountsReceivableWidget` no necesitó cambio: ya sumaba sólo `status = "pending"`.
+  No cambia ningún número hoy (no hay ventas anuladas ni CxC canceladas todavía), pero
+  deja el terreno listo para la fase 4.
+
+Cubierto por `tests/Feature/SaleCancellationScaffoldingTest.php` (7 tests): los dos
+scopes, su aplicación en el endpoint de ventas del día, en el cuadre y en el listado de
+CxC del empleado, la fecha forzada en servidor pese a un valor manipulado del cliente, y
+la ausencia de `DeleteAction` en la edición de venta.
+
+---
+
+## 13. Matriz de tests
+
+**Caso app (§4)**
+- anular venta simple → `sale_quantity` vuelve al valor previo, `stock` al original
+- anular venta con regalía → `royalties_quantity` revertido y `assigned_product_movements` eliminado
+- anular venta con cambio → ídem `changes_quantity`
+- anular venta con línea normal + regalía del mismo producto → ambos revertidos, sin doble conteo
+- **anular como admin (usuario sin `employee`)** → resuelve la asignación por `sale.employee_id`, no por `Auth`
+- asignación inexistente → falla con mensaje claro, sin revertir nada a medias
+- reversión que dejaría `sale_quantity` negativo → se recorta a 0 y se registra warning
+- el inventario **no** se toca en ningún caso app
+
+**Caso web (§5)**
+- anular venta web → `finished_product_inventories.stock` restaurado
+- se crea el asiento compensatorio, **no se borra** el `salida` original
+- venta con varias líneas y varios inventarios → un compensatorio por asiento
+- colisión `reference_id` entre venta #N y devolución #N → no compensa el ajeno
+- el cajero no tiene asignación → no se toca ningún `detail_assigned_products`
+
+**Reglas de negocio (§0)**
+- R1: venta de ayer → rechazada (aunque no haya cuadre)
+- R2: cuadre `completed` del día → rechazada
+- **R2: cuadre `pending` del día → rechazada** (el caso que cubre §4.4)
+- R3: venta de contado en estado `paid` → **se anula correctamente**
+- R4: venta a crédito sin pagos → se anula y la CxC queda en `CANCELLED` con `cancelled_at`
+- R5: venta a crédito con un pago registrado → rechazada, y la CxC sigue `PENDING`
+- **R6: venta a crédito con abono inicial (`cash_amount > 0`, 0 filas en `payments`) → se anula**, y la respuesta/UI informa el monto a devolver
+- R7: venta con `created_at` de hoy pero `sale_date` retrofechada (histórico) → rechazada
+- **R7 web: `save()` ignora la fecha enviada por el cliente y persiste `now()`** (test de componente Livewire enviando otra fecha)
+- R8: el asiento compensatorio es de tipo `DEVOLUCION`, no `ENTRADA`
+- venta facturada → rechazada
+- CxC cancelada no aparece en `getAccountReceivable` ni cuenta para el límite de cuentas activas del cliente
+
+**Transversales (§7–§9)**
+- anular dos veces (o dos DELETE concurrentes) → revierte una sola vez, responde 200
+- vendedor intentando anular la venta de otro → 403
+- cajero intentando anular una venta que no creó → 403
+- fallo a mitad de la reversión → rollback total, nada queda revertido ni la venta cambia de estado
+- venta anulada deja de contar en cuadre, ranking y listado del día
+- **reintento del móvil con el `client_request_uuid` de una venta anulada → responde "ya registrada", no la re-crea ni la revive**

--- a/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
+++ b/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
@@ -571,7 +571,7 @@ implementación.
 | 1 | **R7 web:** fecha de venta a sólo lectura en el blade + `sale_date = now()` forzado en el servidor (§7.0) | — | ✅ hecho |
 | 2 | `Sale::scopeNotCancelled` + filtrarlo en cuadre, `getSales`, ranking y reportes (§7.1). Scope equivalente para CxC canceladas (§7.2) | — | ✅ hecho |
 | 3 | Migraciones §10: `management_inventory.reference_type` (**bloqueante**), `sales.branch_id`, `cancelled_at`/`cancelled_by`/`cancellation_reason`, `channel`, `payment_reference` + backfill | — | ✅ hecho |
-| 4 | `SaleCancellationService`: precondiciones (§7), reversión app (§4) y web (§5), CxC a `CANCELLED` (§7.2), transacción y bloqueos (§8) | fase 3 | pendiente |
+| 4 | `SaleCancellationService`: precondiciones (§7), reversión app (§4) y web (§5), CxC a `CANCELLED` (§7.2), transacción y bloqueos (§8) | fase 3 | ✅ hecho |
 | 5 | Acción "Anular" en Filament con motivo obligatorio y aviso de devolución del abono (R6) | fase 4 | pendiente |
 | 6 | `DELETE /api/sales/{id}` con pertenencia (§9), idempotencia (§8) y aviso de devolución (R6) | fase 4 | pendiente |
 | 7 | `SET NULL` → `restrictOnDelete` en `account_receivables.sales_id` y `assigned_product_movements.sale_id` (§10.6) | fase 4 | pendiente |
@@ -629,6 +629,51 @@ uno que fuerza una colisión real de `reference_id` entre una venta y una devolu
 el mismo id y verifica que `reference_type` las distingue) y
 `tests/Feature/SaleSchemaMetadataTest.php` (3 tests). Verificado en rojo contra la BD real
 (`jaco`) antes del fix: 3/4 y 3/3 tests fallaban respectivamente.
+
+La fase 4 también está hecha: `app/Services/SaleCancellationService.php` (nuevo) +
+`app/Exceptions/SaleCancellationException.php`.
+
+- **`cancel(Sale $sale, ?string $reason = null): Sale`** — única entrada pública. Bloquea
+  la venta (`lockForUpdate`), corta temprano si ya está `CANCELLED` (idempotencia, §8),
+  valida precondiciones en el orden del §7 (facturada → R1/R7 → R2 → R5), revierte
+  efectos y marca `CANCELLED` con `cancelled_at`/`cancelled_by`/`cancellation_reason`.
+  Todo en una única transacción.
+- **Reversión por evidencia, no por `channel`** (tal como pide §6): se consultan los
+  asientos de `management_inventory` con `reference_type = Sale::class` para esta venta.
+  Las líneas de la venta cuyo `product_id` aparece ahí se tratan como evidencia web
+  (se compensan con `DEVOLUCION`, R8, sin borrar el `SALIDA` original); el resto se trata
+  como evidencia app (se revierte `sale_quantity` contra la `DetailAssignedProduct`
+  resuelta por `sale.employee_id` + `sale.sale_date` — nunca por el usuario autenticado,
+  §4.1). Los movimientos de regalía/cambio se revierten siempre, sin depender de esta
+  clasificación: el vínculo es directo por `assigned_product_movements.sale_id`.
+- **Silent skip prohibido (§4.2):** si una línea no tiene evidencia (ni inventario ni
+  asignación), se aborta toda la anulación con un mensaje que nombra el producto, en vez
+  de revertir parcialmente.
+- **Piso en 0 con warning (§4.5)** al revertir `sale_quantity`, más una aserción
+  defensiva del invariante `stock ≥ 0` tras la reversión — si falla, indica drift previo
+  ajeno a esta venta y aborta la transacción completa.
+- **R4:** la cuenta por cobrar se marca `CANCELLED` + `cancelled_at`, nunca se borra.
+- **Autorización (§9) queda fuera de esta fase a propósito**, tal como delimita la tabla
+  del plan: el servicio no valida pertenencia ni rol, sólo las precondiciones técnicas.
+  Eso corresponde a las fases 5 (Filament) y 6 (API), siguiendo el mismo patrón usado en
+  `AssignedProductMovementController::resolveOwnedDetail` del PR #128 — ownership
+  verificado en el controlador, no en el servicio.
+
+Cubierto por `tests/Feature/SaleCancellationServiceTest.php` (21 tests: 8 caso app, 3
+caso web, 8 precondiciones R1-R6 + factura, 2 idempotencia). Dos hallazgos al escribir
+los tests, ambos corregidos en el propio test antes de dar la fase por cerrada:
+
+1. El escenario original para forzar el fallo del invariante defensivo no lo activaba:
+   restar `sale_quantity` sólo puede subir el `stock` calculado, nunca bajarlo, así que
+   hacía falta que **otro** acumulador (`returned_quantity`) ya excediera `quantity` por
+   sí solo para que la reversión terminara en negativo.
+2. El primer test de idempotencia pasaba incluso sin el guardia `isCancelled()`, porque
+   la reversión de `sale_quantity` es naturalmente resiliente a un doble-revert (el piso
+   en 0 lo absorbe) y la de regalías es query-driven (no vuelve a intentar nada si la fila
+   ya no existe). El guardia sí es indispensable para el **caso web**: sin él, un segundo
+   `cancel()` vuelve a leer los mismos asientos `SALIDA` (no se marcan como compensados) y
+   duplica el stock devuelto. Se agregó un test específico para ese escenario y se
+   verificó en rojo: sin el guardia, el stock queda en 105 en vez de 100.
 
 ---
 

--- a/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
+++ b/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
@@ -1,7 +1,7 @@
 # Análisis: borrado / anulación de ventas
 
 **Fecha:** 2026-08-10
-**Estado:** análisis cerrado — reglas de negocio definidas (§0), sin decisiones pendientes (§11). Listo para implementar (§12).
+**Estado:** ✅ **implementación completa** — fases 0-7 hechas, en la rama `feature/sale-cancellation`.
 **Relacionado:** `docs/devflow/bug-fixes/2026-08-10-assigned-product-movements-known-issues.md` (Pendiente B)
 
 ---
@@ -574,7 +574,7 @@ implementación.
 | 4 | `SaleCancellationService`: precondiciones (§7), reversión app (§4) y web (§5), CxC a `CANCELLED` (§7.2), transacción y bloqueos (§8) | fase 3 | ✅ hecho |
 | 5 | Acción "Anular" en Filament con motivo obligatorio y aviso de devolución del abono (R6) | fase 4 | ✅ hecho |
 | 6 | `DELETE /api/sales/{id}` con pertenencia (§9), idempotencia (§8) y aviso de devolución (R6) | fase 4 | ✅ hecho |
-| 7 | `SET NULL` → `restrictOnDelete` en `account_receivables.sales_id` y `assigned_product_movements.sale_id` (§10.6) | fase 4 | pendiente |
+| 7 | `SET NULL` → `restrictOnDelete` en `account_receivables.sales_id` y `assigned_product_movements.sale_id` (§10.6) | fase 4 | ✅ hecho |
 
 Las fases 0, 1 y 2 eran independientes entre sí y de todo lo demás, y ya están hechas:
 
@@ -760,6 +760,41 @@ motivo, 404, 403, idempotencia HTTP (dos `DELETE` seguidos, ambos 200), dos
 precondiciones mapeadas a 422 con el mensaje exacto del servicio, y R6 presente/ausente
 según corresponda. Verificado en rojo desactivando quirúrgicamente el check de
 pertenencia y el cálculo de `cash_to_return`.
+
+La fase 7 también está hecha — última del plan: dos migraciones puramente de esquema,
+sin lógica de aplicación.
+
+- `2026_08_12_000001_...`: `account_receivables.sales_id` pasa de `nullOnDelete()` a
+  `restrictOnDelete()`.
+- `2026_08_12_000002_...`: `assigned_product_movements.sale_id`, mismo cambio.
+- **No hay backfill ni migración de datos**: es sólo cambiar la regla `ON DELETE` de la
+  FK (`dropForeign` + `foreign(...)->restrictOnDelete()`), no toca filas existentes.
+- Verificado contra la BD real (`jaco`): antes del cambio, ambas eran `SET NULL`; después,
+  `RESTRICT` — confirmado consultando `information_schema.REFERENTIAL_CONSTRAINTS`. El
+  `down()` de ambas migraciones se probó explícitamente (rollback + re-migrate) y
+  restaura `SET NULL` correctamente.
+- **No cambia nada en el comportamiento de la aplicación**: como ninguna venta se borra
+  físicamente desde el código (fase 0 retiró los últimos botones que lo intentaban, y
+  `SaleCancellationService` sólo hace `UPDATE` sobre `sales`, nunca `DELETE`), el único
+  efecto de este cambio es que un intento de borrado físico futuro —manual, por script, o
+  por una regresión que reintroduzca un botón de borrar— falla ahora con un error de base
+  de datos explícito, en vez de dejar una CxC o una regalía huérfana en silencio. Es
+  puramente defensivo.
+- El borrado de la fila *hija* (un `assigned_product_movement` individual, como hace
+  `AssignedProductMovementService::deleteMovement` durante una anulación normal) **sigue
+  funcionando exactamente igual**: `RESTRICT` sólo gobierna qué pasa al borrar el padre
+  (`sales`), nunca al borrar el hijo.
+
+Cubierto por `tests/Feature/SaleForeignKeyRestrictTest.php` (4 tests): bloqueo del borrado
+de una venta con CxC asociada, bloqueo del borrado de una venta con un movimiento de
+regalía asociado, borrado de un movimiento individual sin afectarse por la restricción, y
+una anulación completa (con CxC y regalía) verificando que `SaleCancellationService` sigue
+funcionando sin fricción bajo el nuevo esquema. Verificado en rojo editando temporalmente
+el contenido de ambas migraciones (revertidas a `nullOnDelete()`) y confirmando que los
+dos tests de bloqueo fallan sin `RESTRICT` — el archivo de test corre contra SQLite en
+memoria, migrado desde cero en cada corrida, así que la verificación tuvo que tocar el
+archivo de migración directamente en vez de usar `migrate:rollback` sobre la BD de
+desarrollo (que no comparte estado con la base de tests).
 
 ---
 

--- a/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
+++ b/docs/devflow/specs/2026-08-10-sale-deletion-analysis.md
@@ -570,7 +570,7 @@ implementación.
 | 0 | Retirar `DeleteAction`/`DeleteBulkAction` de Filament (hoy sólo producen un error SQL) | — | ✅ hecho (rama `feature/sale-cancellation`) |
 | 1 | **R7 web:** fecha de venta a sólo lectura en el blade + `sale_date = now()` forzado en el servidor (§7.0) | — | ✅ hecho |
 | 2 | `Sale::scopeNotCancelled` + filtrarlo en cuadre, `getSales`, ranking y reportes (§7.1). Scope equivalente para CxC canceladas (§7.2) | — | ✅ hecho |
-| 3 | Migraciones §10: `management_inventory.reference_type` (**bloqueante**), `sales.branch_id`, `cancelled_at`/`cancelled_by`/`cancellation_reason`, `channel`, `payment_reference` + backfill | — | pendiente |
+| 3 | Migraciones §10: `management_inventory.reference_type` (**bloqueante**), `sales.branch_id`, `cancelled_at`/`cancelled_by`/`cancellation_reason`, `channel`, `payment_reference` + backfill | — | ✅ hecho |
 | 4 | `SaleCancellationService`: precondiciones (§7), reversión app (§4) y web (§5), CxC a `CANCELLED` (§7.2), transacción y bloqueos (§8) | fase 3 | pendiente |
 | 5 | Acción "Anular" en Filament con motivo obligatorio y aviso de devolución del abono (R6) | fase 4 | pendiente |
 | 6 | `DELETE /api/sales/{id}` con pertenencia (§9), idempotencia (§8) y aviso de devolución (R6) | fase 4 | pendiente |
@@ -595,6 +595,40 @@ Cubierto por `tests/Feature/SaleCancellationScaffoldingTest.php` (7 tests): los 
 scopes, su aplicación en el endpoint de ventas del día, en el cuadre y en el listado de
 CxC del empleado, la fecha forzada en servidor pese a un valor manipulado del cliente, y
 la ausencia de `DeleteAction` en la edición de venta.
+
+La fase 3 también está hecha:
+
+- **`management_inventory.reference_type`** (nullable, `after reference_id`) — backfill
+  histórico por patrón de descripción (única señal disponible; no hay ninguna otra forma
+  de reconstruir el origen retroactivamente): 621 filas → `AssignedProduct::class`, 30 →
+  `ProductReturn::class`, 1.390 sin clasificar (asientos legacy con `reference_id` ya
+  NULL — no había nada que resolver). `ManagementInventoryService::processMovement` y
+  los 4 métodos `register*` ahora aceptan `?string $referenceType` y lo persisten; se
+  actualizaron los 4 call sites existentes (`SaleService`, `CreateSale` web,
+  `ProductReturnService` ×2, `DetailsRelationManager` ×3) para pasar la clase
+  correspondiente. `MovementsInventoryRelationManager` (ajuste manual) sigue sin
+  referencia, como antes.
+- **`sales.branch_id`, `payment_reference`** — ya se enviaban a `Sale::create()` pero
+  Eloquent los descartaba en silencio por no existir. Backfill de `branch_id` desde
+  `employees.branch_id` (426/426 resueltas). El backfill se implementó recorriendo por
+  empleado en vez de `UPDATE...JOIN`: esa sintaxis no es portable a SQLite, que es el
+  motor de la suite de tests.
+- **`sales.cancelled_at`, `cancelled_by`, `cancellation_reason`** — columnas de
+  auditoría, sin backfill (no hay ventas anuladas todavía). Relación `cancelledBy()`
+  agregada al modelo.
+- **`sales.channel`** (`SaleChannelEnum::APP|WEB`) — backfill por evidencia: existe
+  `AssignedProduct` para `(employee_id, sale_date)` ⇒ `app`, si no ⇒ `web`. Resultado
+  real: las 426 ventas históricas clasificaron como `app` (consistente con que no hay
+  ningún asiento de inventario con `reference_type = Sale::class` en el histórico: nunca
+  hubo una venta web con movimiento de inventario en esta base). El enum deja escrito en
+  su docblock que la reversión de la fase 4 no debe decidir por este campo, sino por
+  evidencia directa — igual criterio que el backfill.
+
+Cubierto por `tests/Feature/ManagementInventoryReferenceTypeTest.php` (4 tests, incluido
+uno que fuerza una colisión real de `reference_id` entre una venta y una devolución con
+el mismo id y verifica que `reference_type` las distingue) y
+`tests/Feature/SaleSchemaMetadataTest.php` (3 tests). Verificado en rojo contra la BD real
+(`jaco`) antes del fix: 3/4 y 3/3 tests fallaban respectivamente.
 
 ---
 

--- a/resources/views/livewire/sales/create-sale.blade.php
+++ b/resources/views/livewire/sales/create-sale.blade.php
@@ -93,17 +93,14 @@
                                     @enderror
                                 </div>
 
-                                <!-- Fecha -->
+                                <!-- Fecha: sólo lectura, la fija el servidor al guardar (no editable) -->
                                 <div>
                                     <label for="sale_date"
                                         class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                                        Fecha <span class="text-red-500">*</span>
+                                        Fecha
                                     </label>
-                                    <input type="date" wire:model="sale_date" id="sale_date" required
-                                        class="w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                                    @error('sale_date')
-                                        <span class="text-red-500 text-xs">{{ $message }}</span>
-                                    @enderror
+                                    <input type="date" wire:model="sale_date" id="sale_date" readonly disabled
+                                        class="w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 shadow-sm bg-gray-100 dark:bg-gray-800 cursor-not-allowed">
                                 </div>
                             </div>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -61,6 +61,7 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::post('/', [SaleController::class, 'createSale']);
         Route::get('/', [SaleController::class, 'getSales']);
         Route::get('/{id}', [SaleController::class, 'getSaleDetailsBySaleId']);
+        Route::delete('/{id}', [SaleController::class, 'cancelSale']);
     });
 
     Route::prefix('account-receivable')->group(function () {

--- a/tests/Feature/CancellationReviewFixesTest.php
+++ b/tests/Feature/CancellationReviewFixesTest.php
@@ -1,0 +1,196 @@
+<?php
+
+use App\Enums\AccountReceivableStatusEnum;
+use App\Enums\PaymentTermEnum;
+use App\Enums\SaleStatusEnum;
+use App\Enums\TypeInventoryManagementEnum;
+use App\Filament\Resources\AccountReceivableResource\Widgets\AccountReceivableStatsOverview;
+use App\Filament\Resources\ManagementInventoryResource;
+use App\Models\AccountReceivable;
+use App\Models\AssignedProduct;
+use App\Models\Branch;
+use App\Models\Client;
+use App\Models\DetailAssignedProduct;
+use App\Models\Employee;
+use App\Models\ManagementInventory;
+use App\Models\Product;
+use App\Models\Sale;
+use App\Models\TypePrice;
+use App\Models\User;
+use App\Services\SaleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión de tres hallazgos de la revisión del PR #129
+ * (docs/devflow/specs/2026-08-10-sale-deletion-analysis.md), fuera de
+ * SaleCancellationService/PaymentService (ya cubiertos en
+ * PaymentAccountReceivableRaceTest.php):
+ *
+ *  #4 — AccountReceivableStatsOverview no excluía CxC canceladas de sus totales.
+ *  #5 — ManagementInventoryResource permitía borrar evidencia de anulación.
+ *  #6 — StatsOverview/SalesRankingWidget duplicaban a mano el criterio "cancelada".
+ */
+
+function invokeGetStats(object $widget): array
+{
+    $method = new ReflectionMethod($widget, 'getStats');
+    $method->setAccessible(true);
+
+    return $method->invoke($widget);
+}
+
+function statValue(array $stats, string $label): mixed
+{
+    foreach ($stats as $stat) {
+        $reflection = new ReflectionClass($stat);
+        $property = $reflection->getProperty('label');
+        $property->setAccessible(true);
+
+        if ($property->getValue($stat) === $label) {
+            $valueProperty = $reflection->getProperty('value');
+            $valueProperty->setAccessible(true);
+
+            return $valueProperty->getValue($stat);
+        }
+    }
+
+    throw new RuntimeException("Stat '{$label}' no encontrado.");
+}
+
+// --- #4: AccountReceivableStatsOverview excluye CxC canceladas ---
+
+it('excludes cancelled accounts receivable from the CxC dashboard totals', function () {
+    $employee = Employee::factory()->create();
+    $client = Client::factory()->create();
+    $sale = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'payment_term' => PaymentTermEnum::CREDIT,
+    ]);
+
+    AccountReceivable::create([
+        'sales_id' => $sale->id,
+        'name' => 'CxC activa',
+        'total_amount' => 100,
+        'remaining_balance' => 60,
+        'status' => AccountReceivableStatusEnum::PENDING,
+    ]);
+    AccountReceivable::create([
+        'sales_id' => $sale->id,
+        'name' => 'CxC cancelada',
+        'total_amount' => 9999,
+        'remaining_balance' => 9999,
+        'status' => AccountReceivableStatusEnum::CANCELLED,
+    ]);
+
+    $stats = invokeGetStats(new AccountReceivableStatsOverview());
+
+    expect(statValue($stats, 'Total Cuentas por Cobrar'))->toBe(1)
+        ->and(statValue($stats, 'Monto Total'))->toBe('L. 100.00');
+});
+
+it('does not let a cancelled account receivable distort the collection percentage', function () {
+    $employee = Employee::factory()->create();
+    $client = Client::factory()->create();
+    $sale = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'payment_term' => PaymentTermEnum::CREDIT,
+    ]);
+
+    // Totalmente pagada.
+    AccountReceivable::create([
+        'sales_id' => $sale->id,
+        'name' => 'CxC pagada',
+        'total_amount' => 200,
+        'remaining_balance' => 0,
+        'status' => AccountReceivableStatusEnum::PAID,
+    ]);
+    // Cancelada: nunca se cobró nada, no debería aparecer ni en el
+    // numerador ni en el denominador del porcentaje.
+    AccountReceivable::create([
+        'sales_id' => $sale->id,
+        'name' => 'CxC cancelada',
+        'total_amount' => 300,
+        'remaining_balance' => 300,
+        'status' => AccountReceivableStatusEnum::CANCELLED,
+    ]);
+
+    $stats = invokeGetStats(new AccountReceivableStatsOverview());
+
+    // Sin la CxC cancelada en el denominador: 200/200 = 100%.
+    expect(statValue($stats, 'Porcentaje de Cobranza'))->toBe('100.0%');
+});
+
+// --- #5: ManagementInventoryResource ya no permite borrado masivo ---
+
+it('management inventory table no longer offers a bulk delete action', function () {
+    $widget = new class extends \Filament\Widgets\TableWidget {
+        public function table(\Filament\Tables\Table $table): \Filament\Tables\Table
+        {
+            return ManagementInventoryResource::table($table);
+        }
+    };
+
+    $table = $widget->table(\Filament\Tables\Table::make($widget));
+
+    expect($table->getBulkActions())->toBeEmpty();
+});
+
+// --- #6: el criterio de "cancelada" en queries crudas viene de un único lugar ---
+
+it('Sale::cancelledStatusValue matches the enum used by scopeNotCancelled', function () {
+    expect(Sale::cancelledStatusValue())->toBe(SaleStatusEnum::CANCELLED->value);
+});
+
+it('sales ranking widget still excludes cancelled sales after reusing Sale::cancelledStatusValue()', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $client = Client::factory()->create();
+
+    Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'status' => SaleStatusEnum::PAID,
+        'total_amount' => 100,
+        'payment_method' => 'cash',
+    ]);
+    Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'status' => SaleStatusEnum::CANCELLED,
+        'total_amount' => 9999,
+        'payment_method' => 'cash',
+    ]);
+
+    $widget = new \App\Filament\Widgets\SalesRankingWidget();
+    $table = $widget->table(\Filament\Tables\Table::make($widget));
+
+    $row = $table->getQuery()->where('employees.id', $employee->id)->first();
+
+    expect((float) $row->total_amount)->toBe(100.0);
+});
+
+it('stats overview top employee query still excludes cancelled sales after reusing Sale::cancelledStatusValue()', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $client = Client::factory()->create();
+
+    Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'sale_date' => now(),
+        'status' => SaleStatusEnum::CANCELLED,
+        'total_amount' => 9999,
+        'payment_method' => 'cash',
+    ]);
+
+    $stats = invokeGetStats(new \App\Filament\Widgets\StatsOverview());
+
+    // Sin ninguna venta no-cancelada este mes, "Empleado Destacado" no debe
+    // resolver al empleado cuya única venta está anulada.
+    expect(statValue($stats, 'Empleado Destacado'))->toBe('Sin datos');
+});

--- a/tests/Feature/ManagementInventoryReferenceTypeTest.php
+++ b/tests/Feature/ManagementInventoryReferenceTypeTest.php
@@ -1,0 +1,231 @@
+<?php
+
+use App\Enums\PaymentTermEnum;
+use App\Enums\TypeInventoryManagementEnum;
+use App\Models\AssignedProduct;
+use App\Models\Branch;
+use App\Models\Client;
+use App\Models\Employee;
+use App\Models\FinishedProductInventory;
+use App\Models\ManagementInventory;
+use App\Models\Product;
+use App\Models\ProductPrice;
+use App\Models\ProductReturn;
+use App\Models\ProductUnit;
+use App\Models\Sale;
+use App\Models\TaxCategory;
+use App\Models\TypePrice;
+use App\Models\Unit;
+use App\Services\ManagementInventoryService;
+use App\Services\ProductReturnService;
+use App\Services\SaleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión de la fase 3 del análisis de anulación de ventas
+ * (docs/devflow/specs/2026-08-10-sale-deletion-analysis.md §5.2): sin
+ * reference_type, la venta #5 y la devolución #5 eran indistinguibles entre
+ * los asientos de management_inventory. Estos tests verifican que cada
+ * origen de movimiento escribe su propia clase en reference_type.
+ */
+
+it('tags a manual entry movement with no reference_type when none is given', function () {
+    $branch = Branch::factory()->create();
+    $product = Product::factory()->create();
+    $inventory = FinishedProductInventory::create([
+        'product_id' => $product->id,
+        'branch_id' => $branch->id,
+        'stock' => 10,
+    ]);
+
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = \App\Models\User::factory()->create(['employee_id' => $employee->id]);
+    Auth::login($user);
+
+    $movement = app(ManagementInventoryService::class)->processMovement(
+        $inventory,
+        5,
+        TypeInventoryManagementEnum::ENTRADA->value,
+        'Ajuste manual de inventario',
+    );
+
+    expect($movement->reference_id)->toBeNull()
+        ->and($movement->reference_type)->toBeNull();
+});
+
+it('tags the movement with the model class passed as reference_type', function () {
+    $branch = Branch::factory()->create();
+    $product = Product::factory()->create();
+    $inventory = FinishedProductInventory::create([
+        'product_id' => $product->id,
+        'branch_id' => $branch->id,
+        'stock' => 10,
+    ]);
+
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = \App\Models\User::factory()->create(['employee_id' => $employee->id]);
+    Auth::login($user);
+
+    $movement = app(ManagementInventoryService::class)->processMovement(
+        $inventory,
+        3,
+        TypeInventoryManagementEnum::SALIDA->value,
+        'Movimiento de prueba',
+        referenceId: 42,
+        referenceType: Sale::class,
+    );
+
+    expect($movement->reference_id)->toBe(42)
+        ->and($movement->reference_type)->toBe(Sale::class);
+});
+
+it('tags a web sale inventory movement with Sale::class, distinguishing it from a product return with the same id', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = \App\Models\User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+    $category = \App\Models\Category::factory()->create(['name' => 'Test ' . uniqid()]);
+    $product = Product::factory()->create(['category_id' => $category->id, 'is_active' => true]);
+    $typePrice = TypePrice::factory()->create();
+    $unit = Unit::factory()->create();
+    $productUnit = ProductUnit::factory()->create([
+        'product_id' => $product->id,
+        'unit_id' => $unit->id,
+    ]);
+    $taxCategory = TaxCategory::create([
+        'name' => 'Exento',
+        'rate' => 0,
+        'is_active' => true,
+        'is_for_products' => true,
+        'calculation_type' => 'exempt',
+    ]);
+    $productPrice = ProductPrice::factory()->create([
+        'product_id' => $product->id,
+        'type_price_id' => $typePrice->id,
+        'product_unit_id' => $productUnit->id,
+        'tax_category_id' => $taxCategory->id,
+    ]);
+    $inventory = FinishedProductInventory::create([
+        'product_id' => $product->id,
+        'branch_id' => $branch->id,
+        'stock' => 100,
+    ]);
+
+    Auth::login($user);
+
+    // Venta creada desde el flujo "web" (SaleService con inventory_id, sin
+    // asignación de producto): genera un asiento de tipo SALIDA referenciando
+    // la venta.
+    $sale = app(SaleService::class)->createSale(
+        [
+            'client_id' => $client->id,
+            'employee_id' => $employee->id,
+            'sale_date' => now()->toDateString(),
+            'cash_amount' => 100,
+            'payment_method' => 'cash',
+            'payment_term' => PaymentTermEnum::CASH->value,
+            'branch_id' => $branch->id,
+        ],
+        [[
+            'product_id' => $product->id,
+            'name' => $product->name,
+            'type_price_id' => $typePrice->id,
+            'unit_name' => 'Unidad',
+            'quantity' => 2,
+            'base_quantity' => 2,
+            'unit_price_without_tax' => 50,
+            'unit_tax_amount' => 0,
+            'line_subtotal' => 100,
+            'line_tax_amount' => 0,
+            'line_total' => 100,
+            'inventory_id' => $inventory->id,
+        ]],
+    );
+
+    $saleMovement = ManagementInventory::where('model_id', $inventory->id)
+        ->where('type', TypeInventoryManagementEnum::SALIDA->value)
+        ->latest('id')
+        ->first();
+
+    expect($saleMovement->reference_id)->toBe($sale->id)
+        ->and($saleMovement->reference_type)->toBe(Sale::class);
+
+    // Una devolución con el MISMO id numérico que la venta no debe
+    // confundirse con ella: reference_type las distingue.
+    $productReturn = ProductReturn::create([
+        'product_id' => $product->id,
+        'employee_id' => $employee->id,
+        'quantity' => 1,
+        'type' => 'returned',
+        'reason' => 'Prueba de colisión de reference_id',
+        'affects_inventory' => true,
+    ]);
+    // Fuerza el mismo id que la venta para probar la colisión real.
+    \DB::table('product_returns')->where('id', $productReturn->id)->update(['id' => $sale->id]);
+    $productReturn = ProductReturn::find($sale->id);
+
+    app(ProductReturnService::class)->registerInventoryMovement($productReturn);
+
+    $returnMovement = ManagementInventory::where('model_id', $inventory->id)
+        ->where('reference_id', $sale->id)
+        ->where('reference_type', ProductReturn::class)
+        ->first();
+
+    expect($returnMovement)->not->toBeNull()
+        ->and($returnMovement->reference_id)->toBe($saleMovement->reference_id)
+        ->and($returnMovement->reference_type)->not->toBe($saleMovement->reference_type);
+});
+
+it('tags an assigned-product inventory movement with AssignedProduct::class', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = \App\Models\User::factory()->create(['employee_id' => $employee->id]);
+    $product = Product::factory()->create();
+    $assignedProduct = AssignedProduct::factory()->create([
+        'employee_id' => $employee->id,
+        'date' => now(),
+    ]);
+    FinishedProductInventory::create([
+        'product_id' => $product->id,
+        'branch_id' => $branch->id,
+        'stock' => 100,
+    ]);
+
+    Auth::login($user);
+
+    foreach ([
+        \App\Constants\PermissionConstants::DETAIL_ASSIGNED_PRODUCT_CREATE,
+        \App\Constants\PermissionConstants::DETAIL_ASSIGNED_PRODUCT_VIEW,
+        \App\Constants\PermissionConstants::DETAIL_ASSIGNED_PRODUCT_UPDATE,
+        \App\Constants\PermissionConstants::DETAIL_ASSIGNED_PRODUCT_DELETE,
+        \App\Constants\PermissionConstants::DETAIL_ASSIGNED_PRODUCT_LIST,
+    ] as $perm) {
+        \Spatie\Permission\Models\Permission::findOrCreate($perm, 'web');
+    }
+    $user->givePermissionTo([
+        \App\Constants\PermissionConstants::DETAIL_ASSIGNED_PRODUCT_CREATE,
+        \App\Constants\PermissionConstants::DETAIL_ASSIGNED_PRODUCT_VIEW,
+        \App\Constants\PermissionConstants::DETAIL_ASSIGNED_PRODUCT_UPDATE,
+        \App\Constants\PermissionConstants::DETAIL_ASSIGNED_PRODUCT_DELETE,
+        \App\Constants\PermissionConstants::DETAIL_ASSIGNED_PRODUCT_LIST,
+    ]);
+
+    \Livewire\Livewire::test(\App\Filament\Resources\AssignedProductResource\RelationManagers\DetailsRelationManager::class, [
+        'ownerRecord' => $assignedProduct,
+        'pageClass' => \App\Filament\Resources\AssignedProductResource\Pages\EditAssignedProduct::class,
+    ])->callTableAction('create', data: [
+        'product_id' => $product->id,
+        'quantity' => 10,
+    ]);
+
+    $movement = ManagementInventory::where('reference_id', $assignedProduct->id)
+        ->where('type', TypeInventoryManagementEnum::SALIDA->value)
+        ->latest('id')
+        ->first();
+
+    expect($movement)->not->toBeNull()
+        ->and($movement->reference_type)->toBe(AssignedProduct::class);
+});

--- a/tests/Feature/PaymentAccountReceivableRaceTest.php
+++ b/tests/Feature/PaymentAccountReceivableRaceTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use App\Enums\AccountReceivableStatusEnum;
+use App\Enums\PaymentTermEnum;
+use App\Models\AccountReceivable;
+use App\Models\AssignedProduct;
+use App\Models\Branch;
+use App\Models\Client;
+use App\Models\DetailAssignedProduct;
+use App\Models\Employee;
+use App\Models\Product;
+use App\Models\TypePrice;
+use App\Models\User;
+use App\Services\PaymentService;
+use App\Services\SaleCancellationService;
+use App\Services\SaleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: un pago no debe poder registrarse sobre una cuenta por cobrar
+ * ya anulada (R5), ni una anulación debe poder pisar una cuenta que acaba
+ * de recibir un pago real. PaymentService::processPayment validaba el
+ * estado de la CxC sobre el objeto recibido por parámetro, leído ANTES de
+ * abrir su propia transacción — si ese objeto quedaba desactualizado
+ * (p. ej. SaleCancellationService la anuló justo después de que el
+ * controlador la cargara, fuera de esta transacción), la validación de
+ * "sólo cuentas pendientes" corría contra el estado viejo (PENDING en
+ * memoria) en vez del real (CANCELLED en la base), y el pago se registraba
+ * igual, revirtiendo la anulación en silencio.
+ */
+
+function makeCreditSaleWithReceivable(): array
+{
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+    $product = Product::factory()->create(['name' => 'Jugo Naranja', 'is_active' => true]);
+
+    $assignedProduct = AssignedProduct::factory()->create([
+        'employee_id' => $employee->id,
+        'date' => now(),
+    ]);
+    DetailAssignedProduct::factory()->create([
+        'assigned_products_id' => $assignedProduct->id,
+        'product_id' => $product->id,
+        'quantity' => 80,
+        'sale_quantity' => 0,
+        'changes_quantity' => 0,
+        'royalties_quantity' => 0,
+        'returned_quantity' => 0,
+    ]);
+
+    Auth::login($user);
+
+    $sale = app(SaleService::class)->createSale(
+        [
+            'client_id' => $client->id,
+            'employee_id' => $employee->id,
+            'sale_date' => now()->toDateString(),
+            'cash_amount' => 0,
+            'payment_method' => 'cash',
+            'payment_term' => PaymentTermEnum::CREDIT->value,
+            'branch_id' => $branch->id,
+        ],
+        [[
+            'origin' => 'api',
+            'product_id' => $product->id,
+            'name' => $product->name,
+            'type_price_id' => TypePrice::factory()->create()->id,
+            'unit_name' => 'Unidad',
+            'quantity' => 10,
+            'unit_price_without_tax' => 10,
+            'unit_tax_amount' => 0,
+            'line_subtotal' => 100,
+            'line_tax_amount' => 0,
+            'line_total' => 100,
+        ]],
+    );
+
+    return compact('sale');
+}
+
+it('rejects a payment on an account receivable that was cancelled after being loaded (stale in-memory object)', function () {
+    $scenario = makeCreditSaleWithReceivable();
+    $accountReceivable = $scenario['sale']->fresh()->accountReceivable;
+
+    // Simula lo que hace el controlador: carga la CxC (status PENDING en
+    // este objeto PHP)...
+    $staleAccountReceivable = AccountReceivable::find($accountReceivable->id);
+    expect($staleAccountReceivable->status)->toBe(AccountReceivableStatusEnum::PENDING);
+
+    // ...y ANTES de llamar a processPayment(), otra request la anula.
+    app(SaleCancellationService::class)->cancel($scenario['sale']->fresh(), 'Anulación concurrente');
+    expect($accountReceivable->fresh()->status)->toBe(AccountReceivableStatusEnum::CANCELLED);
+
+    // processPayment() recibe el objeto viejo (todavía en memoria como
+    // PENDING) — debe rechazar el pago igual, porque relee y bloquea la
+    // fila dentro de su propia transacción en vez de confiar en el estado
+    // que llegó por parámetro.
+    expect(fn () => PaymentService::processPayment($staleAccountReceivable, [
+        'amount' => 20,
+        'payment_date' => now(),
+        'payment_method' => 'cash',
+        'notes' => null,
+    ]))->toThrow(Exception::class, 'Solo se pueden registrar pagos en cuentas pendientes');
+
+    $fresh = $accountReceivable->fresh();
+    expect($fresh->status)->toBe(AccountReceivableStatusEnum::CANCELLED)
+        ->and($fresh->payments()->count())->toBe(0);
+});
+
+it('still allows a legitimate payment on a pending account receivable through the same locked path', function () {
+    $scenario = makeCreditSaleWithReceivable();
+    $accountReceivable = $scenario['sale']->fresh()->accountReceivable;
+
+    $result = PaymentService::processPayment($accountReceivable, [
+        'amount' => 30,
+        'payment_date' => now(),
+        'payment_method' => 'cash',
+        'notes' => null,
+    ]);
+
+    expect($result['success'])->toBeTrue();
+    expect((float) $accountReceivable->fresh()->remaining_balance)->toBe(70.0);
+});
+
+it('rejects cancelling a sale once its account receivable has just received a payment, even if the AR object held by the caller is stale', function () {
+    $scenario = makeCreditSaleWithReceivable();
+    $sale = $scenario['sale']->fresh();
+
+    PaymentService::processPayment($sale->accountReceivable, [
+        'amount' => 10,
+        'payment_date' => now(),
+        'payment_method' => 'cash',
+        'notes' => null,
+    ]);
+
+    expect(fn () => app(SaleCancellationService::class)->cancel($sale->fresh()))
+        ->toThrow(\App\Exceptions\SaleCancellationException::class, 'pagos registrados');
+
+    expect($sale->fresh()->status)->not->toBe(\App\Enums\SaleStatusEnum::CANCELLED);
+    expect($sale->fresh()->accountReceivable->status)->toBe(AccountReceivableStatusEnum::PENDING);
+});

--- a/tests/Feature/SaleCancellationApiTest.php
+++ b/tests/Feature/SaleCancellationApiTest.php
@@ -1,0 +1,213 @@
+<?php
+
+use App\Enums\PaymentTermEnum;
+use App\Enums\SaleStatusEnum;
+use App\Models\AccountReceivable;
+use App\Models\AssignedProduct;
+use App\Models\Branch;
+use App\Models\Client;
+use App\Models\DetailAssignedProduct;
+use App\Models\Employee;
+use App\Models\Payment;
+use App\Models\Product;
+use App\Models\Sale;
+use App\Models\TypePrice;
+use App\Models\User;
+use App\Services\SaleCancellationService;
+use App\Services\SaleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Fase 6 de docs/devflow/specs/2026-08-10-sale-deletion-analysis.md:
+ * DELETE /api/sales/{id} (app móvil). Pertenencia (§9: sólo el vendedor
+ * dueño), idempotencia HTTP (§8: 200 en reintento) y aviso de devolución
+ * del abono (R6).
+ */
+
+function apiCancelScenario(array $headerOverrides = []): array
+{
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $seller = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+    $product = Product::factory()->create(['name' => 'Jugo Naranja', 'is_active' => true]);
+
+    $assignedProduct = AssignedProduct::factory()->create([
+        'employee_id' => $employee->id,
+        'date' => now(),
+    ]);
+    $detail = DetailAssignedProduct::factory()->create([
+        'assigned_products_id' => $assignedProduct->id,
+        'product_id' => $product->id,
+        'quantity' => 80,
+        'sale_quantity' => 0,
+        'changes_quantity' => 0,
+        'royalties_quantity' => 0,
+        'returned_quantity' => 0,
+    ]);
+
+    Auth::login($seller);
+
+    $sale = app(SaleService::class)->createSale(
+        array_merge([
+            'client_id' => $client->id,
+            'employee_id' => $employee->id,
+            'sale_date' => now()->toDateString(),
+            'cash_amount' => 100,
+            'payment_method' => 'cash',
+            'payment_term' => PaymentTermEnum::CASH->value,
+            'branch_id' => $branch->id,
+        ], $headerOverrides),
+        [[
+            'origin' => 'api',
+            'product_id' => $product->id,
+            'name' => $product->name,
+            'type_price_id' => TypePrice::factory()->create()->id,
+            'unit_name' => 'Unidad',
+            'quantity' => 10,
+            'unit_price_without_tax' => 10,
+            'unit_tax_amount' => 0,
+            'line_subtotal' => 100,
+            'line_tax_amount' => 0,
+            'line_total' => 100,
+        ]],
+    );
+
+    return compact('branch', 'employee', 'seller', 'client', 'product', 'detail', 'sale');
+}
+
+it('cancels a sale via DELETE and reverts sale_quantity', function () {
+    $scenario = apiCancelScenario();
+
+    $this->actingAs($scenario['seller'], 'sanctum');
+
+    $response = $this->deleteJson("/api/sales/{$scenario['sale']->id}")
+        ->assertOk();
+
+    expect($response->json('data.status'))->toBe('cancelled');
+    expect($scenario['sale']->fresh()->status)->toBe(SaleStatusEnum::CANCELLED);
+    expect((float) $scenario['detail']->fresh()->sale_quantity)->toBe(0.0);
+});
+
+it('accepts an optional reason and persists it', function () {
+    $scenario = apiCancelScenario();
+
+    $this->actingAs($scenario['seller'], 'sanctum');
+
+    $this->deleteJson("/api/sales/{$scenario['sale']->id}", ['reason' => 'Error de captura'])
+        ->assertOk();
+
+    expect($scenario['sale']->fresh()->cancellation_reason)->toBe('Error de captura');
+});
+
+it('cancels without a reason: it is optional on this channel', function () {
+    $scenario = apiCancelScenario();
+
+    $this->actingAs($scenario['seller'], 'sanctum');
+
+    $this->deleteJson("/api/sales/{$scenario['sale']->id}")
+        ->assertOk();
+
+    expect($scenario['sale']->fresh()->status)->toBe(SaleStatusEnum::CANCELLED);
+});
+
+it('returns 404 for a sale that does not exist', function () {
+    $seller = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $this->actingAs($seller, 'sanctum');
+
+    $this->deleteJson('/api/sales/999999')->assertStatus(404);
+});
+
+it('returns 403 when the sale belongs to another salesperson', function () {
+    $scenario = apiCancelScenario();
+
+    $intruder = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $this->actingAs($intruder, 'sanctum');
+
+    $this->deleteJson("/api/sales/{$scenario['sale']->id}")->assertStatus(403);
+
+    expect($scenario['sale']->fresh()->status)->not->toBe(SaleStatusEnum::CANCELLED);
+    expect((float) $scenario['detail']->fresh()->sale_quantity)->toBe(10.0);
+});
+
+it('is idempotent over HTTP: retrying the DELETE on an already cancelled sale returns 200, not an error', function () {
+    $scenario = apiCancelScenario();
+    $this->actingAs($scenario['seller'], 'sanctum');
+
+    $this->deleteJson("/api/sales/{$scenario['sale']->id}")->assertOk();
+
+    // Reintento de la cola offline del móvil: debe seguir respondiendo 200.
+    $this->deleteJson("/api/sales/{$scenario['sale']->id}")
+        ->assertOk()
+        ->assertJsonPath('data.status', 'cancelled');
+});
+
+it('maps a rejected precondition (R2: reconciliation exists) to 422 with the exact service message', function () {
+    $scenario = apiCancelScenario();
+
+    \App\Models\DailySalesReconciliation::factory()->create([
+        'employee_id' => $scenario['employee']->id,
+        'branch_id' => $scenario['branch']->id,
+        'reconciliation_date' => now(),
+    ]);
+
+    $this->actingAs($scenario['seller'], 'sanctum');
+
+    $this->deleteJson("/api/sales/{$scenario['sale']->id}")
+        ->assertStatus(422)
+        ->assertJsonFragment(['error' => 'El día ya tiene cuadre; no se puede anular la venta.']);
+});
+
+it('maps a rejected precondition (R5: payments already registered) to 422', function () {
+    $scenario = apiCancelScenario([
+        'cash_amount' => 0,
+        'payment_term' => PaymentTermEnum::CREDIT->value,
+    ]);
+
+    $accountReceivable = $scenario['sale']->fresh()->accountReceivable;
+    Payment::create([
+        'model_type' => AccountReceivable::class,
+        'model_id' => $accountReceivable->id,
+        'amount' => 10,
+        'balance_after_payment' => $accountReceivable->remaining_balance - 10,
+        'payment_date' => now(),
+        'payment_method' => 'cash',
+    ]);
+
+    $this->actingAs($scenario['seller'], 'sanctum');
+
+    $this->deleteJson("/api/sales/{$scenario['sale']->id}")
+        ->assertStatus(422)
+        ->assertJsonFragment(['error' => 'La venta tiene pagos registrados sobre su cuenta por cobrar; no se puede anular.']);
+
+    expect($accountReceivable->fresh()->status)->not->toBe(\App\Enums\AccountReceivableStatusEnum::CANCELLED);
+});
+
+// --- R6: aviso de devolución del abono inicial ---
+
+it('includes cash_to_return and the refund notice for a credit sale with an initial cash_amount', function () {
+    $scenario = apiCancelScenario([
+        'cash_amount' => 35,
+        'payment_term' => PaymentTermEnum::CREDIT->value,
+    ]);
+
+    $this->actingAs($scenario['seller'], 'sanctum');
+
+    $response = $this->deleteJson("/api/sales/{$scenario['sale']->id}")->assertOk();
+
+    expect((float) $response->json('data.cash_to_return'))->toBe(35.0)
+        ->and($response->json('message'))->toContain('35.00');
+});
+
+it('does not include cash_to_return for a cash sale', function () {
+    $scenario = apiCancelScenario();
+
+    $this->actingAs($scenario['seller'], 'sanctum');
+
+    $response = $this->deleteJson("/api/sales/{$scenario['sale']->id}")->assertOk();
+
+    expect($response->json('data.cash_to_return'))->toBeNull();
+});

--- a/tests/Feature/SaleCancellationFilamentActionTest.php
+++ b/tests/Feature/SaleCancellationFilamentActionTest.php
@@ -1,0 +1,273 @@
+<?php
+
+use App\Constants\PermissionConstants;
+use App\Enums\PaymentTermEnum;
+use App\Enums\SaleStatusEnum;
+use App\Enums\UserRole;
+use App\Filament\Resources\SaleResource;
+use App\Filament\Resources\SaleResource\Pages\ViewSale;
+use App\Models\AccountReceivable;
+use App\Models\Branch;
+use App\Models\Client;
+use App\Models\DetailAssignedProduct;
+use App\Models\AssignedProduct;
+use App\Models\Employee;
+use App\Models\Payment;
+use App\Models\Product;
+use App\Models\Sale;
+use App\Models\User;
+use App\Services\SaleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Fase 5 de docs/devflow/specs/2026-08-10-sale-deletion-analysis.md: la
+ * acción "Anular" en Filament (tabla de ventas + página de vista), con
+ * motivo obligatorio y autorización por rol/pertenencia (§9).
+ */
+
+function ensureSalePermissionsExist(): void
+{
+    foreach ([
+        PermissionConstants::SALE_DELETE,
+        PermissionConstants::SALE_VIEW,
+        PermissionConstants::SALE_LIST,
+        PermissionConstants::SALE_CREATE,
+    ] as $perm) {
+        Permission::findOrCreate($perm, 'web');
+    }
+}
+
+/**
+ * Otorga los permisos necesarios para navegar el recurso de ventas en
+ * Filament (list/view/create) más el de anular (delete, reutilizado —
+ * ver comentario en SaleResource::saleCanBeCancelledByCurrentUser).
+ */
+function grantSalePermissions(User $user): void
+{
+    ensureSalePermissionsExist();
+    $user->givePermissionTo([
+        PermissionConstants::SALE_DELETE,
+        PermissionConstants::SALE_VIEW,
+        PermissionConstants::SALE_LIST,
+        PermissionConstants::SALE_CREATE,
+    ]);
+}
+
+/**
+ * Venta "app" cancelable hoy: mismo patrón que SaleCancellationServiceTest.
+ */
+function makeCancellableSale(User $actor, array $overrides = []): array
+{
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $seller = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+    $product = Product::factory()->create(['name' => 'Jugo Naranja', 'is_active' => true]);
+
+    $assignedProduct = AssignedProduct::factory()->create([
+        'employee_id' => $employee->id,
+        'date' => now(),
+    ]);
+    $detail = DetailAssignedProduct::factory()->create([
+        'assigned_products_id' => $assignedProduct->id,
+        'product_id' => $product->id,
+        'quantity' => 80,
+        'sale_quantity' => 0,
+        'changes_quantity' => 0,
+        'royalties_quantity' => 0,
+        'returned_quantity' => 0,
+    ]);
+
+    Auth::login($seller);
+
+    $sale = app(SaleService::class)->createSale(
+        array_merge([
+            'client_id' => $client->id,
+            'employee_id' => $employee->id,
+            'sale_date' => now()->toDateString(),
+            'cash_amount' => 100,
+            'payment_method' => 'cash',
+            'payment_term' => PaymentTermEnum::CASH->value,
+            'branch_id' => $branch->id,
+        ], $overrides['header'] ?? []),
+        [[
+            'origin' => 'api',
+            'product_id' => $product->id,
+            'name' => $product->name,
+            'type_price_id' => \App\Models\TypePrice::factory()->create()->id,
+            'unit_name' => 'Unidad',
+            'quantity' => 10,
+            'unit_price_without_tax' => 10,
+            'unit_tax_amount' => 0,
+            'line_subtotal' => 100,
+            'line_tax_amount' => 0,
+            'line_total' => 100,
+        ]],
+    );
+
+    Auth::login($actor);
+
+    return compact('branch', 'employee', 'seller', 'client', 'product', 'detail', 'sale');
+}
+
+// --- Autorización (§9) ---
+
+it('shows the cancel action to an admin and lets them cancel with a mandatory reason', function () {
+    $admin = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $admin->assignRole(Role::findOrCreate(UserRole::ADMIN->value, 'web'));
+    grantSalePermissions($admin);
+
+    $scenario = makeCancellableSale($admin);
+
+    Livewire::test(ViewSale::class, ['record' => $scenario['sale']->getKey()])
+        ->assertActionVisible('cancel')
+        ->callAction('cancel', data: ['reason' => 'Cliente se arrepintió'])
+        ->assertHasNoActionErrors();
+
+    $fresh = $scenario['sale']->fresh();
+    expect($fresh->status)->toBe(SaleStatusEnum::CANCELLED)
+        ->and($fresh->cancellation_reason)->toBe('Cliente se arrepintió')
+        ->and($fresh->cancelled_by)->toBe($admin->id);
+});
+
+it('requires a reason to cancel: the action fails validation without one', function () {
+    $admin = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $admin->assignRole(Role::findOrCreate(UserRole::ADMIN->value, 'web'));
+    grantSalePermissions($admin);
+
+    $scenario = makeCancellableSale($admin);
+
+    Livewire::test(ViewSale::class, ['record' => $scenario['sale']->getKey()])
+        ->callAction('cancel', data: ['reason' => ''])
+        ->assertHasActionErrors(['reason']);
+
+    expect($scenario['sale']->fresh()->status)->not->toBe(SaleStatusEnum::CANCELLED);
+});
+
+it('allows a cashier to cancel a sale they created themselves', function () {
+    $cashier = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $cashier->assignRole(Role::findOrCreate(UserRole::CASHEER->value, 'web'));
+    grantSalePermissions($cashier);
+
+    $scenario = makeCancellableSale($cashier);
+    // El helper crea la venta autenticado como el vendedor; la fijamos como
+    // creada por el cajero para simular el flujo real de la web.
+    $scenario['sale']->update(['created_by' => $cashier->id]);
+
+    Livewire::test(ViewSale::class, ['record' => $scenario['sale']->fresh()->getKey()])
+        ->assertActionVisible('cancel');
+});
+
+it('hides the cancel action from a cashier for a sale created by someone else', function () {
+    $cashier = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $cashier->assignRole(Role::findOrCreate(UserRole::CASHEER->value, 'web'));
+    grantSalePermissions($cashier);
+
+    $otherCashier = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+
+    $scenario = makeCancellableSale($cashier);
+    $scenario['sale']->update(['created_by' => $otherCashier->id]);
+
+    Livewire::test(ViewSale::class, ['record' => $scenario['sale']->fresh()->getKey()])
+        ->assertActionHidden('cancel');
+});
+
+it('hides the cancel action without the Sale.delete permission', function () {
+    ensureSalePermissionsExist();
+    $employed = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $employed->assignRole(Role::findOrCreate(UserRole::EMPLOYED->value, 'web'));
+    $employed->givePermissionTo([PermissionConstants::SALE_VIEW, PermissionConstants::SALE_LIST]);
+    // Nunca se le otorga Sale.delete: no debe ver el botón de anular.
+
+    $scenario = makeCancellableSale($employed);
+
+    Livewire::test(ViewSale::class, ['record' => $scenario['sale']->fresh()->getKey()])
+        ->assertActionHidden('cancel');
+});
+
+it('hides the cancel action for an already cancelled sale', function () {
+    $admin = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $admin->assignRole(Role::findOrCreate(UserRole::ADMIN->value, 'web'));
+    grantSalePermissions($admin);
+
+    $scenario = makeCancellableSale($admin);
+    app(\App\Services\SaleCancellationService::class)->cancel($scenario['sale']->fresh(), 'Ya anulada');
+
+    Livewire::test(ViewSale::class, ['record' => $scenario['sale']->fresh()->getKey()])
+        ->assertActionHidden('cancel');
+});
+
+it('hides the cancel action for an invoiced sale', function () {
+    $admin = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $admin->assignRole(Role::findOrCreate(UserRole::ADMIN->value, 'web'));
+    grantSalePermissions($admin);
+
+    $scenario = makeCancellableSale($admin);
+    $scenario['sale']->update(['invoice_number' => 1]);
+
+    Livewire::test(ViewSale::class, ['record' => $scenario['sale']->fresh()->getKey()])
+        ->assertActionHidden('cancel');
+});
+
+// --- Precondiciones del servicio reportadas como notificación, no como excepción cruda ---
+
+it('shows a clear notification instead of a crash when the service rejects the cancellation', function () {
+    $admin = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $admin->assignRole(Role::findOrCreate(UserRole::ADMIN->value, 'web'));
+    grantSalePermissions($admin);
+
+    $scenario = makeCancellableSale($admin, [
+        'header' => ['cash_amount' => 0, 'payment_term' => PaymentTermEnum::CREDIT->value],
+    ]);
+
+    $accountReceivable = $scenario['sale']->fresh()->accountReceivable;
+    Payment::create([
+        'model_type' => AccountReceivable::class,
+        'model_id' => $accountReceivable->id,
+        'amount' => 20,
+        'balance_after_payment' => $accountReceivable->remaining_balance - 20,
+        'payment_date' => now(),
+        'payment_method' => 'cash',
+    ]);
+
+    $component = Livewire::test(ViewSale::class, ['record' => $scenario['sale']->fresh()->getKey()])
+        ->callAction('cancel', data: ['reason' => 'Intento con pagos ya registrados']);
+
+    // La acción no lanza: el servicio comunica el rechazo vía notificación,
+    // la venta sigue activa.
+    $component->assertHasNoActionErrors();
+    expect($scenario['sale']->fresh()->status)->not->toBe(SaleStatusEnum::CANCELLED);
+});
+
+it('shows the initial cash_amount refund warning for a credit sale with an advance payment (R6)', function () {
+    $admin = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $admin->assignRole(Role::findOrCreate(UserRole::ADMIN->value, 'web'));
+    grantSalePermissions($admin);
+
+    $scenario = makeCancellableSale($admin, [
+        'header' => ['cash_amount' => 40, 'payment_term' => PaymentTermEnum::CREDIT->value],
+    ]);
+
+    Livewire::test(ViewSale::class, ['record' => $scenario['sale']->fresh()->getKey()])
+        ->mountAction('cancel')
+        ->assertSee('40.00');
+});
+
+// --- Tabla de ventas: misma acción disponible ---
+
+it('exposes the same cancel action on the sales table row', function () {
+    $admin = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    $admin->assignRole(Role::findOrCreate(UserRole::ADMIN->value, 'web'));
+    grantSalePermissions($admin);
+
+    $scenario = makeCancellableSale($admin);
+
+    Livewire::test(\App\Filament\Resources\SaleResource\Pages\ListSales::class)
+        ->assertTableActionVisible('cancel', $scenario['sale']->fresh());
+});

--- a/tests/Feature/SaleCancellationScaffoldingTest.php
+++ b/tests/Feature/SaleCancellationScaffoldingTest.php
@@ -1,0 +1,251 @@
+<?php
+
+use App\Enums\AccountReceivableStatusEnum;
+use App\Enums\SaleStatusEnum;
+use App\Livewire\Reconciliations\CreateReconciliation;
+use App\Livewire\Sales\CreateSale;
+use App\Models\AccountReceivable;
+use App\Models\AssignedProduct;
+use App\Models\Branch;
+use App\Models\Client;
+use App\Models\DetailAssignedProduct;
+use App\Models\Employee;
+use App\Models\Product;
+use App\Models\Sale;
+use App\Models\TypePrice;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión de las fases 0-2 del análisis de anulación de ventas
+ * (docs/devflow/specs/2026-08-10-sale-deletion-analysis.md):
+ *
+ *  - Fase 0: se retira el borrado físico de Filament.
+ *  - Fase 1: la fecha de venta de la web ya no es editable por el cliente.
+ *  - Fase 2: scopes que excluyen ventas/CxC anuladas de sumas y reportes.
+ *
+ * Todavía no existe el servicio de anulación; estos tests fijan el terreno
+ * sobre el que se va a construir.
+ */
+
+// --- Fase 2: Sale::scopeNotCancelled ---
+
+it('excludes cancelled sales from the notCancelled scope', function () {
+    $employee = Employee::factory()->create();
+    $client = Client::factory()->create();
+
+    $active = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'status' => SaleStatusEnum::PAID,
+    ]);
+    $cancelled = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'status' => SaleStatusEnum::CANCELLED,
+    ]);
+
+    $ids = Sale::notCancelled()->pluck('id');
+
+    expect($ids)->toContain($active->id)
+        ->and($ids)->not->toContain($cancelled->id);
+});
+
+it('excludes cancelled sales from the API sales listing of the day', function () {
+    $employee = Employee::factory()->create();
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+
+    $active = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'sale_date' => now(),
+        'status' => SaleStatusEnum::PAID,
+    ]);
+    Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'sale_date' => now(),
+        'status' => SaleStatusEnum::CANCELLED,
+    ]);
+
+    $this->actingAs($user, 'sanctum');
+
+    $response = $this->getJson('/api/sales')->assertOk();
+    $ids = collect($response->json('data'))->pluck('id');
+
+    expect($ids)->toContain($active->id)
+        ->and($ids)->toHaveCount(1);
+});
+
+it('excludes cancelled sales from the daily reconciliation totals', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $client = Client::factory()->create();
+
+    Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'sale_date' => now(),
+        'status' => SaleStatusEnum::PAID,
+        'total_amount' => 100,
+        'payment_term' => 'cash',
+    ]);
+    Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'sale_date' => now(),
+        'status' => SaleStatusEnum::CANCELLED,
+        'total_amount' => 9999,
+        'payment_term' => 'cash',
+    ]);
+
+    Livewire::test(CreateReconciliation::class, ['employee_id' => $employee->id])
+        ->assertSet('sales', fn ($sales) => count($sales) === 1);
+});
+
+// --- Fase 2: AccountReceivable::scopeNotCancelled ---
+
+it('excludes cancelled accounts receivable from the notCancelled scope', function () {
+    $employee = Employee::factory()->create();
+    $client = Client::factory()->create();
+    $sale = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'payment_term' => 'credit',
+    ]);
+
+    $pending = AccountReceivable::create([
+        'sales_id' => $sale->id,
+        'name' => 'CxC pendiente',
+        'total_amount' => 100,
+        'remaining_balance' => 100,
+        'status' => AccountReceivableStatusEnum::PENDING,
+    ]);
+    $cancelled = AccountReceivable::create([
+        'sales_id' => $sale->id,
+        'name' => 'CxC cancelada',
+        'total_amount' => 100,
+        'remaining_balance' => 100,
+        'status' => AccountReceivableStatusEnum::CANCELLED,
+    ]);
+
+    $ids = AccountReceivable::notCancelled()->pluck('id');
+
+    expect($ids)->toContain($pending->id)
+        ->and($ids)->not->toContain($cancelled->id);
+});
+
+it('excludes cancelled accounts receivable from the API listing for the employee', function () {
+    $employee = Employee::factory()->create();
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+    $sale = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'payment_term' => 'credit',
+    ]);
+
+    $pending = AccountReceivable::create([
+        'sales_id' => $sale->id,
+        'name' => 'CxC pendiente',
+        'total_amount' => 100,
+        'remaining_balance' => 100,
+        'status' => AccountReceivableStatusEnum::PENDING,
+        'paid_at' => null,
+    ]);
+    AccountReceivable::create([
+        'sales_id' => $sale->id,
+        'name' => 'CxC cancelada',
+        'total_amount' => 100,
+        'remaining_balance' => 100,
+        'status' => AccountReceivableStatusEnum::CANCELLED,
+        'paid_at' => null,
+    ]);
+
+    $this->actingAs($user, 'sanctum');
+
+    $response = $this->getJson('/api/account-receivable')->assertOk();
+    $ids = collect($response->json('data'))->pluck('id');
+
+    expect($ids)->toContain($pending->id)
+        ->and($ids)->toHaveCount(1);
+});
+
+// --- Fase 1: la fecha de venta de la web no es editable por el cliente ---
+
+it('forces the server date on a web sale regardless of the sale_date sent by the client', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+    $typePrice = TypePrice::factory()->create();
+    $product = Product::factory()->create(['is_active' => true]);
+
+    $this->actingAs($user);
+
+    // Un componente Livewire manipulado podría enviar cualquier sale_date; el
+    // servidor no debe confiar en la propiedad al persistir la venta.
+    $manipulatedDate = now()->subMonth()->format('Y-m-d');
+
+    Livewire::test(CreateSale::class)
+        ->set('client_id', $client->id)
+        ->set('employee_id', $employee->id)
+        ->set('sale_date', $manipulatedDate)
+        ->set('payment_method', 'efectivo')
+        ->set('payment_term', 'cash')
+        ->set('amount_paid', 100)
+        ->set('products', [[
+            'inventory_id' => null,
+            'product_id' => $product->id,
+            'name' => $product->name,
+            'code' => $product->code,
+            'type_price_id' => $typePrice->id,
+            'unit_price_without_tax' => 100,
+            'unit_tax_amount' => 0,
+            'price_include_tax' => false,
+            'price_with_tax' => 100,
+            'quantity' => 1,
+            'base_quantity' => 1,
+            'line_subtotal' => 100,
+            'line_tax_amount' => 0,
+            'line_total' => 100,
+            'tax_rate' => 0,
+            'tax_category_name' => null,
+            'tax_category_id' => null,
+            'unit_abbreviation' => 'u',
+            'unit_name' => 'Unidad',
+            'stock' => 10,
+            'discount_percentage' => 0,
+            'discount_amount' => 0,
+        ]])
+        ->call('updateSaleTotals')
+        ->call('save');
+
+    $sale = Sale::where('client_id', $client->id)->firstOrFail();
+
+    expect($sale->sale_date->toDateString())->toBe(now()->toDateString())
+        ->and($sale->sale_date->toDateString())->not->toBe($manipulatedDate);
+});
+
+// --- Fase 0: el borrado físico ya no está disponible desde Filament ---
+
+it('sale edit page no longer offers a physical delete action', function () {
+    $reflection = new ReflectionMethod(\App\Filament\Resources\SaleResource\Pages\EditSale::class, 'getHeaderActions');
+    $reflection->setAccessible(true);
+
+    $employee = Employee::factory()->create();
+    $client = Client::factory()->create();
+    $sale = Sale::factory()->create(['employee_id' => $employee->id, 'client_id' => $client->id]);
+
+    $page = new \App\Filament\Resources\SaleResource\Pages\EditSale();
+    $page->record = $sale;
+
+    $actions = $reflection->invoke($page);
+    $names = collect($actions)->map(fn ($action) => $action->getName());
+
+    expect($names)->not->toContain('delete');
+});

--- a/tests/Feature/SaleCancellationServiceTest.php
+++ b/tests/Feature/SaleCancellationServiceTest.php
@@ -1,0 +1,568 @@
+<?php
+
+use App\Enums\AccountReceivableStatusEnum;
+use App\Enums\PaymentTermEnum;
+use App\Enums\SaleStatusEnum;
+use App\Enums\TypeInventoryManagementEnum;
+use App\Exceptions\SaleCancellationException;
+use App\Models\AccountReceivable;
+use App\Models\AssignedProduct;
+use App\Models\AssignedProductMovement;
+use App\Models\Branch;
+use App\Models\Category;
+use App\Models\Client;
+use App\Models\DailySalesReconciliation;
+use App\Models\DetailAssignedProduct;
+use App\Models\Employee;
+use App\Models\FinishedProductInventory;
+use App\Models\ManagementInventory;
+use App\Models\Payment;
+use App\Models\Product;
+use App\Models\ProductPrice;
+use App\Models\ProductUnit;
+use App\Models\Sale;
+use App\Models\SaleDetail;
+use App\Models\TaxCategory;
+use App\Models\TypePrice;
+use App\Models\Unit;
+use App\Models\User;
+use App\Services\SaleCancellationService;
+use App\Services\SaleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Fase 4 de docs/devflow/specs/2026-08-10-sale-deletion-analysis.md:
+ * SaleCancellationService. Cubre la matriz de tests del §13 para el caso app
+ * (§4), el caso web (§5), las precondiciones R1-R5 (§7) e idempotencia (§8).
+ */
+
+function cancellationSaleHeader(Employee $employee, Client $client, array $overrides = []): array
+{
+    return array_merge([
+        'client_id' => $client->id,
+        'employee_id' => $employee->id,
+        'sale_date' => now()->toDateString(),
+        'cash_amount' => 100,
+        'payment_method' => 'cash',
+        'payment_term' => PaymentTermEnum::CASH->value,
+        'branch_id' => $employee->branch_id,
+    ], $overrides);
+}
+
+function cancellationSaleLine(int $productId, string $name, float $quantity, ?string $movementType = null): array
+{
+    return [
+        'origin' => 'api',
+        'product_id' => $productId,
+        'name' => $name,
+        'type_price_id' => TypePrice::factory()->create()->id,
+        'unit_name' => 'Unidad',
+        'quantity' => $quantity,
+        'unit_price_without_tax' => 10,
+        'unit_tax_amount' => 0,
+        'line_subtotal' => 10 * $quantity,
+        'line_tax_amount' => 0,
+        'line_total' => 10 * $quantity,
+        'movement_type' => $movementType,
+    ];
+}
+
+/**
+ * Escenario "venta desde la app": empleado con AssignedProduct/detalle hoy,
+ * usuario autenticado con ese employee_id (igual que SaleController).
+ */
+function makeAppSaleScenario(array $detailOverrides = []): array
+{
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+    $product = Product::factory()->create(['name' => 'Jugo Naranja', 'is_active' => true]);
+
+    $assignedProduct = AssignedProduct::factory()->create([
+        'employee_id' => $employee->id,
+        'date' => now(),
+    ]);
+
+    $detail = DetailAssignedProduct::factory()->create(array_merge([
+        'assigned_products_id' => $assignedProduct->id,
+        'product_id' => $product->id,
+        'quantity' => 80,
+        'sale_quantity' => 0,
+        'changes_quantity' => 0,
+        'royalties_quantity' => 0,
+        'returned_quantity' => 0,
+    ], $detailOverrides));
+
+    Auth::login($user);
+
+    return compact('branch', 'employee', 'user', 'client', 'product', 'assignedProduct', 'detail');
+}
+
+/**
+ * Escenario "venta desde la web": producto con inventario en la sucursal,
+ * sin ninguna asignación para el empleado (un cajero no tiene productos
+ * asignados).
+ */
+function makeWebSaleScenario(): array
+{
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+    $category = Category::factory()->create(['name' => 'Test ' . uniqid()]);
+    $product = Product::factory()->create(['category_id' => $category->id, 'is_active' => true, 'name' => 'Jugo Naranja']);
+    $typePrice = TypePrice::factory()->create();
+    $unit = Unit::factory()->create();
+    $productUnit = ProductUnit::factory()->create([
+        'product_id' => $product->id,
+        'unit_id' => $unit->id,
+    ]);
+    $taxCategory = TaxCategory::create([
+        'name' => 'Exento',
+        'rate' => 0,
+        'is_active' => true,
+        'is_for_products' => true,
+        'calculation_type' => 'exempt',
+    ]);
+    ProductPrice::factory()->create([
+        'product_id' => $product->id,
+        'type_price_id' => $typePrice->id,
+        'product_unit_id' => $productUnit->id,
+        'tax_category_id' => $taxCategory->id,
+    ]);
+    $inventory = FinishedProductInventory::create([
+        'product_id' => $product->id,
+        'branch_id' => $branch->id,
+        'stock' => 100,
+    ]);
+
+    Auth::login($user);
+
+    return compact('branch', 'employee', 'user', 'client', 'product', 'typePrice', 'inventory');
+}
+
+function createWebSale(array $scenario, float $quantity = 2): Sale
+{
+    return app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [[
+            'product_id' => $scenario['product']->id,
+            'name' => $scenario['product']->name,
+            'type_price_id' => $scenario['typePrice']->id,
+            'unit_name' => 'Unidad',
+            'quantity' => $quantity,
+            'base_quantity' => $quantity,
+            'unit_price_without_tax' => 10,
+            'unit_tax_amount' => 0,
+            'line_subtotal' => 10 * $quantity,
+            'line_tax_amount' => 0,
+            'line_total' => 10 * $quantity,
+            'inventory_id' => $scenario['inventory']->id,
+        ]],
+    );
+}
+
+// --- Caso app (§4) ---
+
+it('reverts sale_quantity to the previous value and restores stock', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    expect((float) $scenario['detail']->fresh()->sale_quantity)->toBe(10.0);
+
+    $cancelled = app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    expect($cancelled->status)->toBe(SaleStatusEnum::CANCELLED);
+
+    $fresh = $scenario['detail']->fresh();
+    expect((float) $fresh->sale_quantity)->toBe(0.0)
+        ->and((float) $fresh->stock)->toBe(80.0);
+});
+
+it('reverts royalties_quantity and removes the linked assigned_product_movement', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 3, 'royalty')],
+    );
+
+    expect((float) $scenario['detail']->fresh()->royalties_quantity)->toBe(3.0);
+    expect(AssignedProductMovement::where('sale_id', $sale->id)->count())->toBe(1);
+
+    app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    $fresh = $scenario['detail']->fresh();
+    expect((float) $fresh->royalties_quantity)->toBe(0.0)
+        ->and((float) $fresh->stock)->toBe(80.0);
+    expect(AssignedProductMovement::where('sale_id', $sale->id)->count())->toBe(0);
+});
+
+it('reverts changes_quantity the same way as royalties', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 4, 'change')],
+    );
+
+    app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    $fresh = $scenario['detail']->fresh();
+    expect((float) $fresh->changes_quantity)->toBe(0.0)
+        ->and((float) $fresh->stock)->toBe(80.0);
+});
+
+it('reverts both a normal line and a royalty line of the same product without double counting', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [
+            cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 6, 'royalty'),
+            cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 20, null),
+        ],
+    );
+
+    $fresh = $scenario['detail']->fresh();
+    expect((float) $fresh->sale_quantity)->toBe(20.0)
+        ->and((float) $fresh->royalties_quantity)->toBe(6.0);
+
+    app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    $fresh = $scenario['detail']->fresh();
+    expect((float) $fresh->sale_quantity)->toBe(0.0)
+        ->and((float) $fresh->royalties_quantity)->toBe(0.0)
+        ->and((float) $fresh->stock)->toBe(80.0);
+});
+
+it('resolves the assignment by sale.employee_id and sale.sale_date when the actor is an admin without employee', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    // El admin que anula tiene SU PROPIO employee, distinto del vendedor de
+    // la venta: si la reversión usara Auth::user()->employee->id en vez de
+    // sale.employee_id, resolvería la asignación equivocada (o ninguna).
+    $admin = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+    Auth::login($admin);
+
+    $cancelled = app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    expect($cancelled->status)->toBe(SaleStatusEnum::CANCELLED)
+        ->and($cancelled->cancelled_by)->toBe($admin->id);
+
+    expect((float) $scenario['detail']->fresh()->sale_quantity)->toBe(0.0);
+});
+
+it('fails the whole cancellation with a clear message when there is no evidence to revert a line', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    // Se borra la asignación del día: ya no hay evidencia de dónde vino la venta.
+    $scenario['detail']->delete();
+    $scenario['assignedProduct']->delete();
+
+    expect(fn () => app(SaleCancellationService::class)->cancel($sale->fresh()))
+        ->toThrow(SaleCancellationException::class, 'No se encontró evidencia');
+
+    // Nada se revirtió a medias.
+    expect($sale->fresh()->status)->not->toBe(SaleStatusEnum::CANCELLED);
+});
+
+it('floors sale_quantity at zero and logs a warning instead of going negative', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    // Simula un drift previo: alguien bajó sale_quantity por fuera de este flujo.
+    $scenario['detail']->update(['sale_quantity' => 4]);
+
+    app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    expect((float) $scenario['detail']->fresh()->sale_quantity)->toBe(0.0);
+});
+
+it('never touches inventory for an app sale', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    expect(ManagementInventory::where('reference_type', Sale::class)->where('reference_id', $sale->id)->count())->toBe(0);
+});
+
+// --- Caso web (§5) ---
+
+it('restores finished_product_inventories.stock for a web sale', function () {
+    $scenario = makeWebSaleScenario();
+    $sale = createWebSale($scenario, 5);
+
+    expect($scenario['inventory']->fresh()->stock)->toEqual(95);
+
+    app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    expect((float) $scenario['inventory']->fresh()->stock)->toBe(100.0);
+});
+
+it('creates a compensating DEVOLUCION entry without deleting the original SALIDA', function () {
+    $scenario = makeWebSaleScenario();
+    $sale = createWebSale($scenario, 5);
+
+    $salidaBefore = ManagementInventory::where('reference_type', Sale::class)
+        ->where('reference_id', $sale->id)
+        ->where('type', TypeInventoryManagementEnum::SALIDA->value)
+        ->first();
+    expect($salidaBefore)->not->toBeNull();
+
+    app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    // El asiento original sigue existiendo, intacto.
+    expect(ManagementInventory::find($salidaBefore->id))->not->toBeNull();
+
+    $devolucion = ManagementInventory::where('reference_type', Sale::class)
+        ->where('reference_id', $sale->id)
+        ->where('type', TypeInventoryManagementEnum::DEVOLUCION->value)
+        ->first();
+
+    expect($devolucion)->not->toBeNull()
+        ->and((float) $devolucion->quantity)->toBe(5.0);
+});
+
+it('never touches detail_assigned_products for a web sale', function () {
+    $scenario = makeWebSaleScenario();
+    $sale = createWebSale($scenario, 5);
+
+    app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    expect(DetailAssignedProduct::where('product_id', $scenario['product']->id)->count())->toBe(0);
+});
+
+// --- Precondiciones R1-R5 (§7) ---
+
+it('rejects cancelling a sale from a previous day (R1)', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = Sale::factory()->create([
+        'employee_id' => $scenario['employee']->id,
+        'client_id' => $scenario['client']->id,
+        'branch_id' => $scenario['branch']->id,
+        'sale_date' => now()->subDay(),
+        'created_at' => now()->subDay(),
+    ]);
+
+    expect(fn () => app(SaleCancellationService::class)->cancel($sale))
+        ->toThrow(SaleCancellationException::class, 'mismo día');
+});
+
+it('rejects cancelling when the day already has a reconciliation, even pending (R2)', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    DailySalesReconciliation::factory()->create([
+        'employee_id' => $scenario['employee']->id,
+        'branch_id' => $scenario['branch']->id,
+        'reconciliation_date' => now(),
+        'status' => \App\Enums\ReconciliationStatusEnum::PENDING,
+    ]);
+
+    expect(fn () => app(SaleCancellationService::class)->cancel($sale->fresh()))
+        ->toThrow(SaleCancellationException::class, 'cuadre');
+
+    expect((float) $scenario['detail']->fresh()->sale_quantity)->toBe(10.0);
+});
+
+it('cancels a cash sale even when its status is PAID (R3)', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client'], ['cash_amount' => 1000]),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    expect($sale->status)->toBe(SaleStatusEnum::PAID);
+
+    $cancelled = app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    expect($cancelled->status)->toBe(SaleStatusEnum::CANCELLED);
+});
+
+it('cancels a credit sale without payments and marks its account receivable as CANCELLED, not deleted (R4)', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client'], [
+            'cash_amount' => 0,
+            'payment_term' => PaymentTermEnum::CREDIT->value,
+        ]),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    $accountReceivable = $sale->fresh()->accountReceivable;
+    expect($accountReceivable)->not->toBeNull()
+        ->and($accountReceivable->status)->toBe(AccountReceivableStatusEnum::PENDING);
+
+    app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    $freshAccount = $accountReceivable->fresh();
+    expect($freshAccount)->not->toBeNull()
+        ->and($freshAccount->status)->toBe(AccountReceivableStatusEnum::CANCELLED)
+        ->and($freshAccount->cancelled_at)->not->toBeNull();
+});
+
+it('rejects cancelling a credit sale that has at least one payment registered (R5)', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client'], [
+            'cash_amount' => 0,
+            'payment_term' => PaymentTermEnum::CREDIT->value,
+        ]),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    $accountReceivable = $sale->fresh()->accountReceivable;
+    Payment::create([
+        'model_type' => AccountReceivable::class,
+        'model_id' => $accountReceivable->id,
+        'amount' => 50,
+        'balance_after_payment' => $accountReceivable->remaining_balance - 50,
+        'payment_date' => now(),
+        'payment_method' => 'cash',
+    ]);
+
+    expect(fn () => app(SaleCancellationService::class)->cancel($sale->fresh()))
+        ->toThrow(SaleCancellationException::class, 'pagos registrados');
+
+    expect($accountReceivable->fresh()->status)->toBe(AccountReceivableStatusEnum::PENDING);
+    expect((float) $scenario['detail']->fresh()->sale_quantity)->toBe(10.0);
+});
+
+it('allows cancelling a credit sale with an initial cash_amount and no payments row (R6)', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client'], [
+            'cash_amount' => 30,
+            'payment_term' => PaymentTermEnum::CREDIT->value,
+        ]),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    expect((float) $sale->cash_amount)->toBe(30.0);
+    expect(Payment::where('model_type', AccountReceivable::class)->count())->toBe(0);
+
+    $cancelled = app(SaleCancellationService::class)->cancel($sale->fresh());
+
+    expect($cancelled->status)->toBe(SaleStatusEnum::CANCELLED);
+});
+
+it('rejects cancelling an invoiced sale', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = Sale::factory()->create([
+        'employee_id' => $scenario['employee']->id,
+        'client_id' => $scenario['client']->id,
+        'branch_id' => $scenario['branch']->id,
+        'sale_date' => now(),
+        'created_at' => now(),
+        'invoice_number' => 1,
+    ]);
+
+    expect(fn () => app(SaleCancellationService::class)->cancel($sale))
+        ->toThrow(SaleCancellationException::class, 'factura');
+});
+
+// --- Idempotencia (§8) ---
+
+it('is idempotent: cancelling an already cancelled sale is a no-op that does not throw', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client']),
+        [
+            cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10),
+            cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 3, 'royalty'),
+        ],
+    );
+
+    $service = app(SaleCancellationService::class);
+    $service->cancel($sale->fresh());
+    $again = $service->cancel($sale->fresh());
+
+    expect($again->status)->toBe(SaleStatusEnum::CANCELLED);
+    // No se revirtió sale_quantity dos veces (no quedó negativo ni afectado dos veces).
+    expect((float) $scenario['detail']->fresh()->sale_quantity)->toBe(0.0);
+});
+
+it('is idempotent for a web sale: a second cancel does not double-compensate inventory', function () {
+    // El caso donde el guardia de idempotencia SÍ es indispensable: la
+    // reversión de inventario vuelve a leer los mismos asientos SALIDA en
+    // cada llamada (no se marcan como "ya compensados"), así que sin el
+    // corte temprano por sale.isCancelled(), un segundo cancel() generaría
+    // una segunda DEVOLUCION y duplicaría el stock devuelto.
+    $scenario = makeWebSaleScenario();
+    $sale = createWebSale($scenario, 5);
+
+    $service = app(SaleCancellationService::class);
+    $service->cancel($sale->fresh());
+    $service->cancel($sale->fresh());
+
+    expect((float) $scenario['inventory']->fresh()->stock)->toBe(100.0);
+    expect(ManagementInventory::where('reference_type', Sale::class)
+        ->where('reference_id', $sale->id)
+        ->where('type', TypeInventoryManagementEnum::DEVOLUCION->value)
+        ->count())->toBe(1);
+});
+
+it('does not partially apply changes when the reversal fails midway', function () {
+    $scenario = makeAppSaleScenario();
+
+    $sale = app(SaleService::class)->createSale(
+        cancellationSaleHeader($scenario['employee'], $scenario['client'], [
+            'cash_amount' => 0,
+            'payment_term' => PaymentTermEnum::CREDIT->value,
+        ]),
+        [cancellationSaleLine($scenario['product']->id, $scenario['product']->name, 10)],
+    );
+
+    // Fuerza el fallo de la aserción de invariante: restar sale_quantity
+    // sólo puede subir el stock calculado, nunca bajarlo, así que para que
+    // termine negativo hace falta que OTRO acumulador (aquí returned_quantity,
+    // simulando un drift que R2 debería haber evitado) ya exceda quantity
+    // por sí solo, independientemente de lo que se revierta.
+    $scenario['detail']->update(['returned_quantity' => 85]);
+
+    expect(fn () => app(SaleCancellationService::class)->cancel($sale->fresh()))
+        ->toThrow(SaleCancellationException::class);
+
+    // La venta NO quedó cancelada: todo el rollback ocurrió.
+    expect($sale->fresh()->status)->not->toBe(SaleStatusEnum::CANCELLED);
+    expect($sale->fresh()->accountReceivable->status)->toBe(AccountReceivableStatusEnum::PENDING);
+});

--- a/tests/Feature/SaleForeignKeyRestrictTest.php
+++ b/tests/Feature/SaleForeignKeyRestrictTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use App\Enums\PaymentTermEnum;
+use App\Models\AccountReceivable;
+use App\Models\AssignedProduct;
+use App\Models\AssignedProductMovement;
+use App\Models\Branch;
+use App\Models\Client;
+use App\Models\DetailAssignedProduct;
+use App\Models\Employee;
+use App\Models\Product;
+use App\Models\Sale;
+use App\Models\TypePrice;
+use App\Models\User;
+use App\Services\AssignedProductMovementService;
+use App\Services\SaleService;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Fase 7 de docs/devflow/specs/2026-08-10-sale-deletion-analysis.md (§10.6):
+ * account_receivables.sales_id y assigned_product_movements.sale_id pasan
+ * de SET NULL a RESTRICT. Una venta nunca se borra físicamente (fase 0), así
+ * que un intento de DELETE directo sobre `sales` ahora debe fallar
+ * explícitamente en la base de datos en vez de dejar huérfanos en silencio.
+ */
+
+it('blocks deleting a sale that has an account receivable', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $client = Client::factory()->create();
+
+    $sale = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'branch_id' => $branch->id,
+        'payment_term' => PaymentTermEnum::CREDIT,
+    ]);
+
+    AccountReceivable::create([
+        'sales_id' => $sale->id,
+        'name' => 'CxC de prueba',
+        'total_amount' => 100,
+        'remaining_balance' => 100,
+    ]);
+
+    expect(fn () => $sale->delete())->toThrow(QueryException::class);
+
+    // La venta y la CxC siguen intactas: RESTRICT abortó el DELETE.
+    expect(Sale::find($sale->id))->not->toBeNull();
+    expect(AccountReceivable::where('sales_id', $sale->id)->exists())->toBeTrue();
+});
+
+it('blocks deleting a sale that has an assigned product movement', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+    $product = Product::factory()->create(['is_active' => true]);
+
+    $assignedProduct = AssignedProduct::factory()->create([
+        'employee_id' => $employee->id,
+        'date' => now(),
+    ]);
+    $detail = DetailAssignedProduct::factory()->create([
+        'assigned_products_id' => $assignedProduct->id,
+        'product_id' => $product->id,
+        'quantity' => 50,
+    ]);
+
+    $sale = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'branch_id' => $branch->id,
+    ]);
+
+    Auth::login($user);
+    $movement = app(AssignedProductMovementService::class)
+        ->createMovement($detail->id, 'royalty', 3, 'Regalía de prueba', $sale->id);
+
+    expect(fn () => $sale->delete())->toThrow(QueryException::class);
+
+    expect(Sale::find($sale->id))->not->toBeNull();
+    expect(AssignedProductMovement::find($movement->id))->not->toBeNull();
+});
+
+it('still allows deleting an assigned_product_movement row on its own (child deletion is unaffected)', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $product = Product::factory()->create(['is_active' => true]);
+
+    $assignedProduct = AssignedProduct::factory()->create([
+        'employee_id' => $employee->id,
+        'date' => now(),
+    ]);
+    $detail = DetailAssignedProduct::factory()->create([
+        'assigned_products_id' => $assignedProduct->id,
+        'product_id' => $product->id,
+        'quantity' => 50,
+    ]);
+
+    Auth::login($user);
+    $movement = app(AssignedProductMovementService::class)
+        ->createMovement($detail->id, 'change', 2);
+
+    // Borrar el movimiento (el hijo) nunca estuvo restringido: RESTRICT sólo
+    // gobierna qué pasa cuando se borra la venta (el padre).
+    app(AssignedProductMovementService::class)->deleteMovement($movement->id);
+
+    expect(AssignedProductMovement::find($movement->id))->toBeNull();
+});
+
+it('a sale can still be cancelled (updated, not deleted) when it has an account receivable and assigned product movements', function () {
+    // Confirma que RESTRICT no interfiere con la fase 4: la anulación nunca
+    // ejecuta un DELETE sobre `sales`, sólo UPDATE + DELETE de las filas
+    // hijas (movements), que sigue permitido.
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+    $product = Product::factory()->create(['name' => 'Jugo Naranja', 'is_active' => true]);
+
+    $assignedProduct = AssignedProduct::factory()->create([
+        'employee_id' => $employee->id,
+        'date' => now(),
+    ]);
+    DetailAssignedProduct::factory()->create([
+        'assigned_products_id' => $assignedProduct->id,
+        'product_id' => $product->id,
+        'quantity' => 80,
+    ]);
+
+    Auth::login($user);
+
+    $sale = app(SaleService::class)->createSale(
+        [
+            'client_id' => $client->id,
+            'employee_id' => $employee->id,
+            'sale_date' => now()->toDateString(),
+            'cash_amount' => 0,
+            'payment_method' => 'cash',
+            'payment_term' => PaymentTermEnum::CREDIT->value,
+            'branch_id' => $branch->id,
+        ],
+        [[
+            'origin' => 'api',
+            'product_id' => $product->id,
+            'name' => $product->name,
+            'type_price_id' => TypePrice::factory()->create()->id,
+            'unit_name' => 'Unidad',
+            'quantity' => 10,
+            'unit_price_without_tax' => 10,
+            'unit_tax_amount' => 0,
+            'line_subtotal' => 100,
+            'line_tax_amount' => 0,
+            'line_total' => 100,
+        ], [
+            'origin' => 'api',
+            'product_id' => $product->id,
+            'name' => $product->name,
+            'quantity' => 2,
+            'unit_price_without_tax' => 10,
+            'unit_tax_amount' => 0,
+            'line_subtotal' => 20,
+            'line_tax_amount' => 0,
+            'line_total' => 20,
+            'movement_type' => 'royalty',
+        ]],
+    );
+
+    $cancelled = app(\App\Services\SaleCancellationService::class)->cancel($sale->fresh(), 'Prueba RESTRICT');
+
+    expect($cancelled->status)->toBe(\App\Enums\SaleStatusEnum::CANCELLED);
+    expect(Sale::find($sale->id))->not->toBeNull();
+});

--- a/tests/Feature/SaleSchemaMetadataTest.php
+++ b/tests/Feature/SaleSchemaMetadataTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Enums\PaymentTermEnum;
+use App\Enums\SaleChannelEnum;
+use App\Models\Branch;
+use App\Models\Client;
+use App\Models\Employee;
+use App\Models\Sale;
+use App\Models\User;
+use App\Services\SaleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión de la fase 3 del análisis de anulación de ventas
+ * (docs/devflow/specs/2026-08-10-sale-deletion-analysis.md §5.1, §10): antes
+ * de esta migración, branch_id y payment_reference se enviaban a
+ * Sale::create() pero Eloquent los descartaba en silencio por no existir
+ * como columnas ni estar en $fillable.
+ */
+
+it('persists branch_id and payment_reference on a sale created through the API flow', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $user = User::factory()->create(['employee_id' => $employee->id]);
+    $client = Client::factory()->create();
+
+    $this->actingAs($user);
+
+    $sale = app(SaleService::class)->createSale(
+        [
+            'client_id' => $client->id,
+            'employee_id' => $employee->id,
+            'sale_date' => now()->toDateString(),
+            'cash_amount' => 0,
+            'payment_method' => 'deposit',
+            'payment_term' => PaymentTermEnum::CASH->value,
+            'branch_id' => $branch->id,
+            'payment_reference' => 'DEP-00123',
+        ],
+        [],
+    );
+
+    $fresh = $sale->fresh();
+
+    expect($fresh->branch_id)->toBe($branch->id)
+        ->and($fresh->payment_reference)->toBe('DEP-00123')
+        ->and($fresh->branch->id)->toBe($branch->id);
+});
+
+it('exposes the cancellation audit columns and the cancelledBy relation', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $client = Client::factory()->create();
+    $admin = User::factory()->create(['employee_id' => Employee::factory()->create()->id]);
+
+    $sale = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'branch_id' => $branch->id,
+    ]);
+
+    $sale->update([
+        'cancelled_at' => now(),
+        'cancelled_by' => $admin->id,
+        'cancellation_reason' => 'Prueba de regresión de esquema',
+    ]);
+
+    $fresh = $sale->fresh();
+
+    expect($fresh->cancelled_at)->not->toBeNull()
+        ->and($fresh->cancellation_reason)->toBe('Prueba de regresión de esquema')
+        ->and($fresh->cancelledBy->id)->toBe($admin->id);
+});
+
+it('casts the channel column to SaleChannelEnum', function () {
+    $branch = Branch::factory()->create();
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+    $client = Client::factory()->create();
+
+    $sale = Sale::factory()->create([
+        'employee_id' => $employee->id,
+        'client_id' => $client->id,
+        'branch_id' => $branch->id,
+        'channel' => SaleChannelEnum::WEB,
+    ]);
+
+    expect($sale->fresh()->channel)->toBe(SaleChannelEnum::WEB);
+});


### PR DESCRIPTION
## Resumen

Implementa la anulación de ventas de punta a punta, reemplazando el borrado físico (que hoy fallaba por FK, pero sin ninguna reversión de sus efectos si alguna vez se "arreglaba" ese error). Basado en el análisis completo de `docs/devflow/specs/2026-08-10-sale-deletion-analysis.md`, con reglas de negocio (R1-R8) acordadas explícitamente antes de implementar.

**Reglas de negocio:**
- Sólo se puede anular una venta **el mismo día** (`sale_date` y `created_at`).
- Si el día ya tiene cuadre (cualquier estado, incluido `pending`), no se permite.
- Se puede anular aunque la venta esté `paid` (contado).
- Venta a crédito: sólo si su cuenta por cobrar **no tiene pagos registrados**. Se anula la venta y la CxC se marca `CANCELLED` (nunca se borra).
- El abono inicial (`cash_amount`) sí permite anular; la UI avisa cuánto devolver al cliente.
- La reversión de inventario (venta web) usa un asiento compensatorio `DEVOLUCION`, nunca borra el original.

## Las 7 fases (6 commits)

| Fase | Qué hace |
|---|---|
| 0 | Retira `DeleteAction`/`DeleteBulkAction` de Filament — hoy sólo producían un error SQL |
| 1 | Bloquea la edición de `sale_date` en la web (readonly + servidor fuerza `now()`) |
| 2 | `Sale::scopeNotCancelled` / `AccountReceivable::scopeNotCancelled`, aplicados en cuadre, reportes, widgets y endpoints |
| 3 | `management_inventory.reference_type` (resuelve la ambigüedad venta-vs-devolución sobre el mismo `reference_id`) + columnas de auditoría (`branch_id`, `payment_reference`, `channel`, `cancelled_*`) en `sales` |
| 4 | **`SaleCancellationService`** — el núcleo: precondiciones, reversión por evidencia (no por canal), idempotencia, transaccionalidad |
| 5 | Acción "Anular" en Filament (tabla + vista de detalle), motivo obligatorio, autorización por rol/pertenencia |
| 6 | `DELETE /api/sales/{id}` para la app móvil — pertenencia, idempotencia HTTP, aviso de devolución en la respuesta |
| 7 | `SET NULL` → `RESTRICT` en las FKs hacia `sales` — cierre defensivo |

## `SaleCancellationService` — la pieza central

Revierte por **evidencia**, no por un campo de canal persistido: consulta los asientos de `management_inventory` referenciando la venta para decidir, línea por línea, si revertir `sale_quantity` (asignación de producto, venta "app") o compensar inventario (venta "web"). Los movimientos de regalía/cambio se revierten siempre por el vínculo directo `assigned_product_movements.sale_id`.

Un "silent skip" está prohibido: si una línea no tiene evidencia de ningún tipo, se aborta **toda** la anulación con un mensaje que nombra el producto, en vez de revertir parcialmente.

## Hallazgos durante la implementación (no estaban en el plan original)

- **`CashierSaleScope` es código muerto**: está importada en `Sale.php` pero nunca se registra (`addGlobalScope`). El análisis original asumía que ya filtraba por `created_by`. La autorización de "Anular" para cajeros se implementó correctamente con `created_by`, independiente de ese scope muerto — arreglarlo es una tarea aparte, documentada como deuda pendiente.
- **El invariante defensivo de stock no se podía romper como se pensaba**: restar `sale_quantity` sólo puede subir el stock calculado, nunca bajarlo. El test tuvo que inflar `returned_quantity` directamente para forzar el escenario real.
- **La idempotencia sólo es indispensable en el caso web**: en el caso app, un doble-revert es naturalmente absorbido (piso en 0, query-driven). Sin el guardia, un segundo `cancel()` de una venta web sí duplica el stock devuelto (confirmado en rojo: 105 en vez de 100).
- **`UPDATE ... INNER JOIN` no es portable a SQLite** (motor de tests) — el backfill de `branch_id` se reescribió recorriendo por empleado.

## Tests

125 tests en la suite completa (54 nuevos de esta rama). Cada fase se verificó en rojo antes de darla por cerrada — desactivando quirúrgicamente el guardia correspondiente (con restauración inmediata tras cada prueba) y confirmando la falla, no sólo el verde.

## Fuera de alcance (documentado en el spec)

- Anulación parcial (quitar una línea de una venta ya creada).
- Reapertura de cuadres ya cerrados — las reglas R1/R2 lo hacen innecesario por diseño.
- El fix de `CashierSaleScope`/`ListSales::getTableQuery` (empleado vs. creador).

🤖 Generated with [Claude Code](https://claude.com/claude-code)