### PR TITLE
fix(reconciliation): devoluciones de otro cuadre en la pantalla de cuadre

### DIFF
--- a/app/Livewire/Reconciliations/CreateReconciliation.php
+++ b/app/Livewire/Reconciliations/CreateReconciliation.php
@@ -146,7 +146,7 @@ class CreateReconciliation extends Component
         if ($this->employee_id) {
             // Verificar si existe un cuadre para la fecha seleccionada y está completado
             $selectedDate = Carbon::parse($this->reconciliation_date);
-            $existing = DailySalesReconciliation::getForEmployeeAndDate($this->employee_id, $selectedDate);
+            $existing = DailySalesReconciliation::getForEmployeeAndDate($this->employee_id, $selectedDate->toDateString());
 
             if ($existing && $existing->status === ReconciliationStatusEnum::COMPLETED) {
                 session()->flash('warning', 'El empleado seleccionado ya tiene un cuadre completado para la fecha seleccionada.');
@@ -164,7 +164,7 @@ class CreateReconciliation extends Component
         if ($this->employee_id && $this->reconciliation_date) {
             // Verificar si existe un cuadre para la nueva fecha seleccionada
             $selectedDate = Carbon::parse($this->reconciliation_date);
-            $existing = DailySalesReconciliation::getForEmployeeAndDate($this->employee_id, $selectedDate);
+            $existing = DailySalesReconciliation::getForEmployeeAndDate($this->employee_id, $selectedDate->toDateString());
 
             if ($existing && $existing->status === ReconciliationStatusEnum::COMPLETED) {
                 session()->flash('warning', 'El empleado seleccionado ya tiene un cuadre completado para la fecha seleccionada.');
@@ -186,7 +186,7 @@ class CreateReconciliation extends Component
         $selectedDate = Carbon::parse($this->reconciliation_date);
 
         // Verificar si ya existe un cuadre para la fecha seleccionada
-        $existing = DailySalesReconciliation::getForEmployeeAndDate($this->employee_id, $selectedDate);
+        $existing = DailySalesReconciliation::getForEmployeeAndDate($this->employee_id, $selectedDate->toDateString());
 
         if ($existing) {
             $this->current_reconciliation = $existing;
@@ -199,10 +199,17 @@ class CreateReconciliation extends Component
 
             // Cargar el efectivo recibido si existe
             $this->cash_received = $existing->total_cash_received;
-
-            $this->loadDeposits();
-            $this->loadBills();
+        } else {
+            // Sin cuadre para este empleado y fecha hay que soltar el anterior:
+            // si se conserva, las devoluciones, depósitos y facturas del cuadre
+            // previo siguen en pantalla como si fueran de esta selección.
+            $this->current_reconciliation = null;
+            $this->reconciliation_created = false;
+            $this->cash_received = 0.0;
         }
+
+        $this->loadDeposits();
+        $this->loadBills();
 
         // Load sales for the selected date and employee
         $this->sales = Sale::with(['client'])
@@ -809,30 +816,34 @@ class CreateReconciliation extends Component
 
     public function loadReturns(): void
     {
-        // Si tenemos un cuadre específico, cargar devoluciones por reconciliation_id para mayor precisión
-        if ($this->current_reconciliation) {
-            $this->returns = ProductReturn::with('product')
-                ->where('reconciliation_id', $this->current_reconciliation->id)
-                ->get()
-                ->map(function ($return) {
-                    return [
-                        'id' => $return->id,
-                        'product_name' => $return->product->name,
-                        'quantity' => $return->quantity,
-                        'type' => $return->type->getLabel(),
-                        'reason' => $return->reason,
-                        'affects_inventory' => $return->affects_inventory ? 'Sí' : 'No',
-                        'created_at' => $return->created_at->format('H:i:s'),
-                    ];
-                })->toArray();
-            return;
-        }
-
-        // Fallback: si no hay cuadre, usar employee_id y fecha como antes
-        if (!$this->employee_id || !$this->reconciliation_date) {
+        // Las devoluciones siempre nacen junto a un cuadre (el formulario manual
+        // y el sobrante de la asignación crean primero el cuadre pendiente), así
+        // que sin cuadre no hay nada que mostrar. Antes esta rama no asignaba
+        // nada y dejaba en pantalla las devoluciones de la selección anterior.
+        if (!$this->current_reconciliation || !$this->employee_id) {
             $this->returns = [];
             return;
         }
+
+        $this->returns = ProductReturn::with('product')
+            ->where('reconciliation_id', $this->current_reconciliation->id)
+            // Además del cuadre se filtra por empleado: si un reconciliation_id
+            // quedara mal asignado, la devolución de otro vendedor no debe
+            // aparecer —ni sumar— en este cuadre.
+            ->where('employee_id', $this->employee_id)
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(function ($return) {
+                return [
+                    'id' => $return->id,
+                    'product_name' => $return->product->name,
+                    'quantity' => $return->quantity,
+                    'type' => $return->type->getLabel(),
+                    'reason' => $return->reason,
+                    'affects_inventory' => $return->affects_inventory ? 'Sí' : 'No',
+                    'created_at' => $return->created_at->format('H:i:s'),
+                ];
+            })->toArray();
     }
 
     public function loadMovements(): void

--- a/tests/Feature/ReconciliationProductReturnsScopeTest.php
+++ b/tests/Feature/ReconciliationProductReturnsScopeTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use App\Enums\ProductReturnTypeEnum;
+use App\Enums\ReconciliationStatusEnum;
+use App\Livewire\Reconciliations\CreateReconciliation;
+use App\Models\Bill;
+use App\Models\Branch;
+use App\Models\DailySalesReconciliation;
+use App\Models\Employee;
+use App\Models\Product;
+use App\Models\ProductReturn;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * La sección de «Devoluciones de productos» del cuadre debe mostrar sólo las
+ * devoluciones del día y del empleado que se está cuadrando.
+ *
+ * El estado del cuadre (current_reconciliation, depósitos, facturas, efectivo
+ * recibido) sólo se refrescaba cuando existía un cuadre para el empleado y la
+ * fecha elegidos. Al cambiar a un empleado o a una fecha sin cuadre, ese estado
+ * se quedaba apuntando al cuadre anterior y la pantalla seguía mostrando sus
+ * devoluciones.
+ */
+
+function makeReconciliationWithReturn(Employee $employee, Branch $branch, string $date, string $productName): array
+{
+    $reconciliation = DailySalesReconciliation::factory()->create([
+        'employee_id' => $employee->id,
+        'branch_id' => $branch->id,
+        'reconciliation_date' => $date,
+        'status' => ReconciliationStatusEnum::PENDING,
+        'total_cash_received' => 500,
+    ]);
+
+    $product = Product::factory()->create(['name' => $productName, 'is_active' => true]);
+
+    $return = ProductReturn::create([
+        'product_id' => $product->id,
+        'employee_id' => $employee->id,
+        'reconciliation_id' => $reconciliation->id,
+        'quantity' => 5,
+        'type' => ProductReturnTypeEnum::DAMAGED,
+        'reason' => 'Producto dañado en ruta',
+        'affects_inventory' => false,
+    ]);
+
+    return compact('reconciliation', 'product', 'return');
+}
+
+beforeEach(function () {
+    $this->branch = Branch::factory()->create();
+    $this->employeeA = Employee::factory()->create(['branch_id' => $this->branch->id]);
+    $this->employeeB = Employee::factory()->create(['branch_id' => $this->branch->id]);
+
+    $user = User::factory()->create(['employee_id' => $this->employeeA->id]);
+    Auth::login($user);
+});
+
+it('clears the returns when switching to an employee that has no reconciliation', function () {
+    makeReconciliationWithReturn($this->employeeA, $this->branch, now()->toDateString(), 'Jugo de Naranja 500ml');
+
+    $component = Livewire::test(CreateReconciliation::class, ['employee_id' => $this->employeeA->id]);
+
+    // El empleado A sí tiene devoluciones del día.
+    expect($component->get('returns'))->toHaveCount(1);
+
+    // El empleado B no tiene cuadre: no debe heredar las del A.
+    $component->set('employee_id', $this->employeeB->id);
+
+    expect($component->get('returns'))->toBeEmpty();
+});
+
+it('clears the returns when switching to a date that has no reconciliation', function () {
+    makeReconciliationWithReturn($this->employeeA, $this->branch, now()->toDateString(), 'Jugo de Naranja 500ml');
+
+    $component = Livewire::test(CreateReconciliation::class, ['employee_id' => $this->employeeA->id]);
+
+    expect($component->get('returns'))->toHaveCount(1);
+
+    $component->set('reconciliation_date', now()->subDays(3)->format('Y-m-d'));
+
+    expect($component->get('returns'))->toBeEmpty();
+});
+
+it('does not leak the previous reconciliation object when the new selection has none', function () {
+    $first = makeReconciliationWithReturn($this->employeeA, $this->branch, now()->toDateString(), 'Jugo de Naranja 500ml');
+
+    $component = Livewire::test(CreateReconciliation::class, ['employee_id' => $this->employeeA->id]);
+
+    expect($component->get('current_reconciliation')?->id)->toBe($first['reconciliation']->id);
+
+    $component->set('employee_id', $this->employeeB->id);
+
+    // Sin cuadre para el empleado B, no debe quedar el objeto del A: de ahí
+    // salían las devoluciones, depósitos y facturas equivocadas.
+    expect($component->get('current_reconciliation'))->toBeNull()
+        ->and($component->get('reconciliation_created'))->toBeFalse();
+});
+
+it('clears bills and cash received too when the new selection has no reconciliation', function () {
+    $first = makeReconciliationWithReturn($this->employeeA, $this->branch, now()->toDateString(), 'Jugo de Naranja 500ml');
+
+    Bill::create([
+        'model_id' => $first['reconciliation']->id,
+        'description' => 'Combustible',
+        'amount' => 250,
+        'reference_number' => 'F-001',
+        'branch_id' => $this->branch->id,
+    ]);
+
+    $component = Livewire::test(CreateReconciliation::class, ['employee_id' => $this->employeeA->id]);
+
+    expect($component->get('bills'))->toHaveCount(1)
+        ->and((float) $component->get('cash_received'))->toBe(500.0);
+
+    $component->set('employee_id', $this->employeeB->id);
+
+    expect($component->get('bills'))->toBeEmpty()
+        ->and((float) $component->get('cash_received'))->toBe(0.0);
+});
+
+it('shows each employee its own returns when both have a reconciliation the same day', function () {
+    makeReconciliationWithReturn($this->employeeA, $this->branch, now()->toDateString(), 'Jugo de Naranja 500ml');
+    makeReconciliationWithReturn($this->employeeB, $this->branch, now()->toDateString(), 'Jugo de Piña 500ml');
+
+    $component = Livewire::test(CreateReconciliation::class, ['employee_id' => $this->employeeA->id]);
+
+    expect($component->get('returns'))->toHaveCount(1)
+        ->and($component->get('returns')[0]['product_name'])->toBe('Jugo de Naranja 500ml');
+
+    $component->set('employee_id', $this->employeeB->id);
+
+    expect($component->get('returns'))->toHaveCount(1)
+        ->and($component->get('returns')[0]['product_name'])->toBe('Jugo de Piña 500ml');
+});
+
+it('never shows a return that belongs to another employee, even if attached to this reconciliation', function () {
+    // Defensa en profundidad: aunque un reconciliation_id quedara mal
+    // asignado, la devolución de otro empleado no debe aparecer en su cuadre.
+    $first = makeReconciliationWithReturn($this->employeeA, $this->branch, now()->toDateString(), 'Jugo de Naranja 500ml');
+
+    $intruder = Product::factory()->create(['name' => 'Jugo Ajeno 1L', 'is_active' => true]);
+    ProductReturn::create([
+        'product_id' => $intruder->id,
+        'employee_id' => $this->employeeB->id,
+        'reconciliation_id' => $first['reconciliation']->id,
+        'quantity' => 3,
+        'type' => ProductReturnTypeEnum::RETURNED,
+        'reason' => 'Devolución de otro empleado',
+        'affects_inventory' => false,
+    ]);
+
+    $component = Livewire::test(CreateReconciliation::class, ['employee_id' => $this->employeeA->id]);
+
+    expect($component->get('returns'))->toHaveCount(1)
+        ->and($component->get('returns')[0]['product_name'])->toBe('Jugo de Naranja 500ml');
+});


### PR DESCRIPTION
## Problema

La sección de **Devoluciones de productos** del cuadre diario mostraba devoluciones que no correspondían ni al día ni al empleado que se estaba cuadrando.

## La causa raíz no estaba en las devoluciones

`loadEmployeeDataOnly()` sólo refrescaba `current_reconciliation` **cuando existía** un cuadre para el empleado y la fecha elegidos:

```php
if ($existing) {
    $this->current_reconciliation = $existing;
    // ...
}
// ← si NO existe, conserva el valor anterior
```

Al cambiar a un empleado (o a una fecha) sin cuadre, la variable seguía apuntando al cuadre **anterior**, y `loadReturns()` cargaba fielmente las devoluciones de ese cuadre.

Eso implica que el problema era **más amplio que las devoluciones**: depósitos, facturas y efectivo recibido también se cargaban sólo dentro de esa rama, así que se arrastraban igual entre selecciones. Está cubierto con un test.

## Segundo defecto: el fallback de `loadReturns()` estaba vacío

```php
// Fallback: si no hay cuadre, usar employee_id y fecha como antes
if (!$this->employee_id || !$this->reconciliation_date) {
    $this->returns = [];
    return;
}
// ← con employee_id y fecha presentes, el método no asignaba NADA
```

El comentario prometía un fallback que nunca se escribió, así que dejaba el arreglo intacto con los datos previos. Ahora limpia, y además del `reconciliation_id` filtra por `employee_id`: si un `reconciliation_id` quedara mal asignado, la devolución de otro vendedor no debe aparecer ni sumar en este cuadre.

## Un matiz sobre «devoluciones del día»

El filtro es **por el cuadre al que pertenecen, no por `created_at`** — deliberadamente. En producción hay dos devoluciones creadas el 12/06 que pertenecen legítimamente al cuadre del 11/06 (el cajero cuadró a la mañana siguiente). Filtrar por fecha de creación las habría ocultado.

## Hallazgo colateral: por qué esta pantalla no tenía tests

`DailySalesReconciliation::getForEmployeeAndDate()` declara `string $date` pero recibía un `Carbon` en tres llamadas. En MySQL cuela por coerción; en **SQLite devuelve `NULL` siempre**, porque `whereDate` termina comparando contra `'2026-08-11 00:00:00'`.

Eso hacía imposible testear esta pantalla — los primeros tests de este PR fallaban en la carga inicial por ese motivo, no por el bug. Es probablemente la razón de que el bug llegara a producción sin red de seguridad. Se corrige pasando `->toDateString()`.

## Nota sobre las devoluciones «registradas en la app»

Al investigar quedó claro que **la API no tiene endpoint de devoluciones**: `ProductReturn::create` sólo existe en la pantalla de cuadre (formulario manual y sobrante de la asignación). Si se espera que la app pueda registrarlas, eso es desarrollo nuevo y no entra en este arreglo.

## Tests

`ReconciliationProductReturnsScopeTest` (6 nuevos). Suite completa: **164 passed**.

Cada arreglo se verificó en rojo por separado: revirtiendo el reset de estado fallan 3 tests; revirtiendo el filtro por empleado falla 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)